### PR TITLE
Use WORKFLOW_TOKEN to trigger builds after branch sync

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,6 +1,13 @@
 # Branch Synchronization Workflow
 # Automatically rebases feature branches when master is updated
 # Equivalent to branch-sync.yml from Azure DevOps
+#
+# To trigger build workflows after sync, create a PAT:
+# 1. https://github.com/settings/tokens?type=beta → Generate new token
+# 2. Grant: Repository → Contents & Pull requests (Read/Write)
+# 3. Add to repository secrets as WORKFLOW_TOKEN
+# Without PAT, branches sync but builds won't trigger (GITHUB_TOKEN limitation)
+# See .github/GITHUB_APP_SETUP.md for advanced GitHub App setup
 
 name: Branch Sync
 
@@ -26,7 +33,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT if available, otherwise GITHUB_TOKEN (won't trigger builds)
+          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -36,7 +44,7 @@ jobs:
       - name: Sync Feature Branches
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             


### PR DESCRIPTION
## 📝 Description
- Replace `GITHUB_TOKEN` with `WORKFLOW_TOKEN` in branch-sync workflow to enable build triggers

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions