### PR TITLE
Move visit time validation to real-time revalidation in VisitDetailViewModel

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -594,15 +594,13 @@ class VisitDetailViewModel
     private fun visitDoneChanged(value: Boolean, visit: VisitState) {
         newState {
             val updatedList = visitList.toMutableList().apply {
-                val hasVisitTimeError = !value && visit.hasVisitTimeError
                 set(
                     this@apply.indexOfById(visit),
                     visit.copy(
-                        isDone = value,
-                        hasVisitTimeError = hasVisitTimeError
+                        isDone = value
                     )
                 )
-            }
+            }.revalidatePendingVisits(householder)
             copy(
                 visitList = updatedList,
                 eventState = UiEventState.Idle

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -998,7 +998,9 @@ class VisitDetailViewModel
                         conversation.id == visit.nextConversationId
                     }
                     visit.asState(conversation)
-                }.reindexIfNeeded()
+                }
+                    .reindexIfNeeded()
+                    .revalidatePendingVisits(householder)
                 newState {
                     copy(
                         householder = householder,

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -594,7 +594,14 @@ class VisitDetailViewModel
     private fun visitDoneChanged(value: Boolean, visit: VisitState) {
         newState {
             val updatedList = visitList.toMutableList().apply {
-                set(this@apply.indexOfById(visit), visit.copy(isDone = value))
+                val hasVisitTimeError = !value && visit.hasVisitTimeError
+                set(
+                    this@apply.indexOfById(visit),
+                    visit.copy(
+                        isDone = value,
+                        hasVisitTimeError = hasVisitTimeError
+                    )
+                )
             }
             copy(
                 visitList = updatedList,
@@ -606,8 +613,11 @@ class VisitDetailViewModel
     private fun visitDateAccepted(visit: VisitState, dateTime: LocalDateTime) {
         newState {
             val updatedList = visitList.toMutableList().apply {
-                set(this@apply.indexOfById(visit), visit.copy(date = dateTime))
-            }
+                set(
+                    this@apply.indexOfById(visit),
+                    visit.copy(date = dateTime)
+                )
+            }.revalidatePendingVisits(householder)
             copy(
                 visitList = updatedList,
                 eventState = UiEventState.Idle
@@ -738,32 +748,6 @@ class VisitDetailViewModel
     }
 
     private fun saveClicked() {
-        // Validate visit times before saving
-        val householder = _uiState.value.householder
-        val visitListWithValidation = _uiState.value.visitList.map { visit ->
-            if (visit.wasRemoved || visit.isDone) {
-                visit.copy(hasVisitTimeError = false)
-            } else {
-                val isValid = visitTimeValidator.isValidVisitTime(
-                    visit.date,
-                    householder.preferredDay,
-                    householder.preferredTime
-                )
-                visit.copy(hasVisitTimeError = !isValid)
-            }
-        }
-
-        val hasValidationErrors = visitListWithValidation.any { it.hasVisitTimeError }
-        if (hasValidationErrors) {
-            newState {
-                copy(
-                    visitList = visitListWithValidation,
-                    eventState = UiEventState.ValidationError
-                )
-            }
-            return
-        }
-
         // Check if there are pending visits that need calendar integration
         val hasPendingVisits = _uiState.value.visitList.any { !it.isDone && !it.wasRemoved }
 
@@ -909,8 +893,10 @@ class VisitDetailViewModel
 
     private fun preferredDayChanged(value: VisitPreferredDay) {
         newState {
+            val updatedHouseholder = householder.copy(preferredDay = value)
             copy(
-                householder = householder.copy(preferredDay = value),
+                householder = updatedHouseholder,
+                visitList = visitList.revalidatePendingVisits(updatedHouseholder),
                 eventState = UiEventState.Idle
             )
         }
@@ -918,10 +904,27 @@ class VisitDetailViewModel
 
     private fun preferredTimeChanged(value: VisitPreferredTime) {
         newState {
+            val updatedHouseholder = householder.copy(preferredTime = value)
             copy(
-                householder = householder.copy(preferredTime = value),
+                householder = updatedHouseholder,
+                visitList = visitList.revalidatePendingVisits(updatedHouseholder),
                 eventState = UiEventState.Idle
             )
+        }
+    }
+
+    private fun List<VisitState>.revalidatePendingVisits(householder: HouseholderState): List<VisitState> {
+        return map { visit ->
+            if (visit.wasRemoved || visit.isDone) {
+                return@map visit.copy(hasVisitTimeError = false)
+            }
+
+            val isValid = visitTimeValidator.isValidVisitTime(
+                visit.date,
+                householder.preferredDay,
+                householder.preferredTime
+            )
+            visit.copy(hasVisitTimeError = !isValid)
         }
     }
 

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -535,7 +535,9 @@ class VisitDetailViewModel
                 visitType = nextVisitType,
                 date = nextVisitDate
             )
-            val updatedVisitList = listOf(nextVisit).plus(visitList)
+            val updatedVisitList = listOf(nextVisit)
+                .plus(visitList)
+                .revalidatePendingVisits(householder)
             copy(
                 visitList = updatedVisitList,
                 eventState = UiEventState.Idle

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -505,6 +505,134 @@ class VisitDetailViewModelTest {
         assertTrue(copiedText.contains("Morning"))
     }
 
+    @Test
+    fun `onEvent with PreferredDayChanged sets hasVisitTimeError on pending visits when invalid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredDayChanged(VisitPreferredDay.MONDAY))
+
+        // Assert
+        assertTrue(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with PreferredDayChanged clears hasVisitTimeError on pending visits when valid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = true)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredDayChanged(VisitPreferredDay.MONDAY))
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with PreferredTimeChanged sets hasVisitTimeError on pending visits when invalid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredTimeChanged(VisitPreferredTime.MORNING))
+
+        // Assert
+        assertTrue(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with PreferredTimeChanged clears hasVisitTimeError on pending visits when valid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = true)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredTimeChanged(VisitPreferredTime.MORNING))
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with VisitDateAccepted sets hasVisitTimeError when invalid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        val visit = viewModel.uiState.value.visitList.first()
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDateAccepted(visit, TEST_DATE_TIME.plusDays(1)))
+
+        // Assert
+        assertTrue(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with VisitDateAccepted clears hasVisitTimeError when valid`() {
+        // Arrange
+        val viewModel = createViewModel(visitTimeValidResult = true)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        val visit = viewModel.uiState.value.visitList.first()
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDateAccepted(visit, TEST_DATE_TIME.plusDays(1)))
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with VisitDoneChanged to true clears hasVisitTimeError`() {
+        // Arrange - trigger a validation error first
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredDayChanged(VisitPreferredDay.MONDAY))
+        val visit = viewModel.uiState.value.visitList.first()
+        assertTrue(visit.hasVisitTimeError)
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDoneChanged(visit, true))
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `onEvent with VisitDoneChanged to false preserves hasVisitTimeError when error already present`() {
+        // Arrange - trigger a validation error on a pending (not-done) visit
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredDayChanged(VisitPreferredDay.MONDAY))
+        val visit = viewModel.uiState.value.visitList.first()
+        assertTrue(visit.hasVisitTimeError)
+        assertFalse(visit.isDone)
+
+        // Act - re-dispatch not-done on a visit that already has an error
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDoneChanged(visit, false))
+
+        // Assert
+        assertTrue(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
+    @Test
+    fun `revalidatePendingVisits does not set hasVisitTimeError on done visits`() {
+        // Arrange - mark the visit as done first, then trigger revalidation with invalid result
+        val viewModel = createViewModel(visitTimeValidResult = false)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        val visit = viewModel.uiState.value.visitList.first()
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDoneChanged(visit, true))
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.PreferredDayChanged(VisitPreferredDay.MONDAY))
+
+        // Assert - done visit should never have a time error
+        assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
+    }
+
     private fun createViewModel(
         conversationRepositoryRef: MockReferenceHolder<ConversationRepository>? = null,
         householderRepositoryRef: MockReferenceHolder<HouseholderRepository>? = null,
@@ -513,7 +641,8 @@ class VisitDetailViewModelTest {
         householderLatitude: Double? = null,
         householderLongitude: Double? = null,
         householderPreferredDay: VisitPreferredDay = VisitPreferredDay.ANY,
-        householderPreferredTime: VisitPreferredTime = VisitPreferredTime.ANY
+        householderPreferredTime: VisitPreferredTime = VisitPreferredTime.ANY,
+        visitTimeValidResult: Boolean = true
     ): VisitDetailViewModel {
         val dispatchers = DispatcherProvider(
             io = mainDispatcherRule.dispatcher
@@ -549,7 +678,7 @@ class VisitDetailViewModelTest {
             on { hasCalendarPermission() } doReturn false
         }
         val visitTimeValidator = mock<VisitTimeValidator> {
-            on { isValidVisitTime(any(), any(), any()) } doReturn true
+            on { isValidVisitTime(any(), any(), any()) } doReturn visitTimeValidResult
         }
         val dateTimeProvider = mock<DateTimeProvider> {
             on { nowLocalDateTime() } doReturn TEST_DATE_TIME


### PR DESCRIPTION
## 📝 Description
- Moved visit time validation from `saveClicked()` into a shared `revalidatePendingVisits()` extension function, making validation run in real time whenever the user changes a visit date, preferred day, or preferred time — instead of only on save.
- Clears `hasVisitTimeError` when a visit is marked as done.
- Removed the pre-save validation block entirely since errors are now surfaced reactively.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions