### PR TITLE
chore: split android compileSdk and targetSdk versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,12 +16,12 @@ plugins {
 
 android {
     namespace = "com.msmobile.visitas"
-    compileSdk = libs.versions.android.sdk.get().toInt()
+    compileSdk = libs.versions.android.compile.sdk.get().toInt()
 
     defaultConfig {
         applicationId = "com.msmobile.visitas"
         minSdk = libs.versions.android.min.sdk.get().toInt()
-        targetSdk = libs.versions.android.sdk.get().toInt()
+        targetSdk = libs.versions.android.target.sdk.get().toInt()
         versionCode = requireEnvVariable(EnvKeys.VERSION_CODE).toInt()
         versionName = requireVersionName()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activity-compose = "1.13.0"
 agp = "9.2.1"
-android-compile-sdk="36"
+android-compile-sdk="37"
 android-min-sdk="26"
 android-target-sdk="36"
 androidx-test = "1.7.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,9 @@
 [versions]
 activity-compose = "1.13.0"
 agp = "9.2.1"
+android-compile-sdk="36"
 android-min-sdk="26"
-android-sdk="36"
+android-target-sdk="36"
 androidx-test = "1.7.0"
 androidx-test-ext-junit = "1.3.0"
 com-google-devtools-ksp = "2.3.7"


### PR DESCRIPTION
## 📝 Description
- Split `android-sdk` version into separate `android-compile-sdk` and `android-target-sdk` entries in `libs.versions.toml`, keeping alphabetical order
- Updated `build.gradle.kts` to reference the new split version keys
- Bumped `android-compile-sdk` to 37
## 🐞 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):
## ☑️ Checklist
- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions