### PR TITLE
Add AppFunctions integration to expose visits to Gemini

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,10 @@ room {
     schemaDirectory("$projectDir/schemas")
 }
 
+ksp {
+    arg("appfunctions:aggregateAppFunctions", "true")
+}
+
 sentry {
     val sentryOrg = System.getenv(EnvKeys.SENTRY_ORG)
     val sentryProject = System.getenv(EnvKeys.SENTRY_PROJECT)
@@ -152,6 +156,10 @@ easylauncher {
 }
 
 dependencies {
+
+    implementation(libs.appfunctions)
+    implementation(libs.appfunctions.service)
+    ksp(libs.appfunctions.compiler)
 
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.runtime.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,9 @@
         android:theme="@style/Theme.Visitas"
         tools:targetApi="36">
 
+        <!-- AppFunctions service declarations and metadata are auto-injected via
+             manifest merging by the androidx.appfunctions:appfunctions-service library. -->
+
         <!-- Disable Sentry auto-init; manual init in VisitasApp -->
         <meta-data
             android:name="io.sentry.auto-init"

--- a/app/src/main/java/com/msmobile/visitas/VisitasApp.kt
+++ b/app/src/main/java/com/msmobile/visitas/VisitasApp.kt
@@ -1,11 +1,22 @@
 package com.msmobile.visitas
 
 import android.app.Application
+import androidx.appfunctions.service.AppFunctionConfiguration
+import com.msmobile.visitas.appfunctions.VisitAppFunctions
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.android.core.SentryAndroid
+import javax.inject.Inject
 
 @HiltAndroidApp
-class VisitasApp : Application() {
+class VisitasApp : Application(), AppFunctionConfiguration.Provider {
+
+    @Inject lateinit var visitAppFunctions: VisitAppFunctions
+
+    override val appFunctionConfiguration: AppFunctionConfiguration
+        get() = AppFunctionConfiguration.Builder()
+            .addEnclosingClassFactory(VisitAppFunctions::class.java) { visitAppFunctions }
+            .build()
+
     override fun onCreate() {
         super.onCreate()
         initSentry()

--- a/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
+++ b/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
@@ -4,16 +4,20 @@ import androidx.appfunctions.AppFunctionContext
 import androidx.appfunctions.AppFunctionInvalidArgumentException
 import androidx.appfunctions.AppFunctionSerializable
 import androidx.appfunctions.service.AppFunction
+import com.msmobile.visitas.util.DateTimeProvider
+import com.msmobile.visitas.util.DispatcherProvider
+import com.msmobile.visitas.util.LocaleProvider
 import com.msmobile.visitas.visit.VisitHouseholderRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 
 class VisitAppFunctions @Inject constructor(
-    private val visitHouseholderRepository: VisitHouseholderRepository
+    private val visitHouseholderRepository: VisitHouseholderRepository,
+    private val dateTimeProvider: DateTimeProvider,
+    private val dispatcherProvider: DispatcherProvider,
+    private val localeProvider: LocaleProvider,
 ) {
     @AppFunctionSerializable(isDescribedByKDoc = true)
     data class VisitItem(
@@ -54,9 +58,9 @@ class VisitAppFunctions @Inject constructor(
          * Omit to list all upcoming pending visits.
          */
         dateFilter: String? = null
-    ): VisitListResult = withContext(Dispatchers.IO) {
+    ): VisitListResult = withContext(dispatcherProvider.io) {
         val allVisits = visitHouseholderRepository.getAll()
-        val todayStart = LocalDate.now().atStartOfDay()
+        val todayStart = dateTimeProvider.nowLocalDateTime().toLocalDate().atStartOfDay()
         val tomorrowStart = todayStart.plusDays(1)
         val dayAfterTomorrowStart = todayStart.plusDays(2)
 
@@ -80,7 +84,7 @@ class VisitAppFunctions @Inject constructor(
             )
         }
 
-        val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d 'at' h:mm a", Locale.getDefault())
+        val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d 'at' h:mm a", localeProvider.getLocale())
         VisitListResult(
             visits = filtered.map { visit ->
                 VisitItem(

--- a/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
+++ b/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 
+
 class VisitAppFunctions @Inject constructor(
     private val visitHouseholderRepository: VisitHouseholderRepository,
     private val dateTimeProvider: DateTimeProvider,
@@ -67,24 +68,28 @@ class VisitAppFunctions @Inject constructor(
         val filtered = when (dateFilter?.lowercase(Locale.ROOT)) {
             // Omitted: default to all upcoming pending visits.
             null -> allVisits.filter { !it.isDone && it.date >= todayStart }
-            "today" -> allVisits.filter {
+            VisitDateFilter.TODAY.value -> allVisits.filter {
                 !it.isDone && it.date >= todayStart && it.date < tomorrowStart
             }
-            "tomorrow" -> allVisits.filter {
+
+            VisitDateFilter.TOMORROW.value -> allVisits.filter {
                 !it.isDone && it.date >= tomorrowStart && it.date < dayAfterTomorrowStart
             }
-            "past_due" -> allVisits.filter {
+
+            VisitDateFilter.PAST_DUE.value -> allVisits.filter {
                 !it.isDone && it.date < todayStart
             }
-            "done" -> allVisits.filter { it.isDone }
+
+            VisitDateFilter.DONE.value -> allVisits.filter { it.isDone }
             // Provided but unrecognized: surface an error so the agent retries with a
             // documented value instead of silently returning a wrong result set.
             else -> throw AppFunctionInvalidArgumentException(
-                "Unknown dateFilter '$dateFilter'. Accepted values: today, tomorrow, past_due, done."
+                "Unknown dateFilter '$dateFilter'. Accepted values: ${VisitDateFilter.entries.joinToString { it.value }}."
             )
         }
 
-        val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d 'at' h:mm a", localeProvider.getLocale())
+        val formatter =
+            DateTimeFormatter.ofPattern("EEEE, MMMM d 'at' h:mm a", localeProvider.getLocale())
         VisitListResult(
             visits = filtered.map { visit ->
                 VisitItem(
@@ -97,5 +102,12 @@ class VisitAppFunctions @Inject constructor(
             },
             count = filtered.size
         )
+    }
+
+    private enum class VisitDateFilter(val value: String) {
+        TODAY("today"),
+        TOMORROW("tomorrow"),
+        PAST_DUE("past_due"),
+        DONE("done"),
     }
 }

--- a/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
+++ b/app/src/main/java/com/msmobile/visitas/appfunctions/VisitAppFunctions.kt
@@ -1,0 +1,97 @@
+package com.msmobile.visitas.appfunctions
+
+import androidx.appfunctions.AppFunctionContext
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import androidx.appfunctions.AppFunctionSerializable
+import androidx.appfunctions.service.AppFunction
+import com.msmobile.visitas.visit.VisitHouseholderRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.inject.Inject
+
+class VisitAppFunctions @Inject constructor(
+    private val visitHouseholderRepository: VisitHouseholderRepository
+) {
+    @AppFunctionSerializable(isDescribedByKDoc = true)
+    data class VisitItem(
+        /** Subject or topic discussed during this visit. */
+        val subject: String,
+        /** Full name of the person to visit. */
+        val householderName: String,
+        /** Street address of the person to visit. */
+        val address: String,
+        /** Scheduled date and time as a human-readable string. */
+        val scheduledDate: String,
+        /** Type of visit: FIRST_VISIT, RETURN_VISIT, or BIBLE_STUDY. */
+        val visitType: String
+    )
+
+    @AppFunctionSerializable(isDescribedByKDoc = true)
+    data class VisitListResult(
+        /** Visits matching the requested filter. */
+        val visits: List<VisitItem>,
+        /** Total number of matching visits. */
+        val count: Int
+    )
+
+    /**
+     * Lists scheduled visits filtered by date.
+     * Use this to answer questions like "What visits do I have today?",
+     * "Show me tomorrow's visits", or "What visits are past due?"
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun listVisits(
+        appFunctionContext: AppFunctionContext,
+        /**
+         * Optional date filter. Accepted values:
+         * "today" – visits scheduled for today,
+         * "tomorrow" – visits scheduled for tomorrow,
+         * "past_due" – overdue visits not yet completed,
+         * "done" – completed visits.
+         * Omit to list all upcoming pending visits.
+         */
+        dateFilter: String? = null
+    ): VisitListResult = withContext(Dispatchers.IO) {
+        val allVisits = visitHouseholderRepository.getAll()
+        val todayStart = LocalDate.now().atStartOfDay()
+        val tomorrowStart = todayStart.plusDays(1)
+        val dayAfterTomorrowStart = todayStart.plusDays(2)
+
+        val filtered = when (dateFilter?.lowercase(Locale.ROOT)) {
+            // Omitted: default to all upcoming pending visits.
+            null -> allVisits.filter { !it.isDone && it.date >= todayStart }
+            "today" -> allVisits.filter {
+                !it.isDone && it.date >= todayStart && it.date < tomorrowStart
+            }
+            "tomorrow" -> allVisits.filter {
+                !it.isDone && it.date >= tomorrowStart && it.date < dayAfterTomorrowStart
+            }
+            "past_due" -> allVisits.filter {
+                !it.isDone && it.date < todayStart
+            }
+            "done" -> allVisits.filter { it.isDone }
+            // Provided but unrecognized: surface an error so the agent retries with a
+            // documented value instead of silently returning a wrong result set.
+            else -> throw AppFunctionInvalidArgumentException(
+                "Unknown dateFilter '$dateFilter'. Accepted values: today, tomorrow, past_due, done."
+            )
+        }
+
+        val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d 'at' h:mm a", Locale.getDefault())
+        VisitListResult(
+            visits = filtered.map { visit ->
+                VisitItem(
+                    subject = visit.subject,
+                    householderName = visit.householderName,
+                    address = visit.householderAddress,
+                    scheduledDate = visit.date.format(formatter),
+                    visitType = visit.type.name
+                )
+            },
+            count = filtered.size
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.13.0"
-appfunctions = "1.0.0-alpha09"
 agp = "9.2.1"
 android-compile-sdk="37"
 android-min-sdk="26"
 android-target-sdk="36"
 androidx-test = "1.7.0"
 androidx-test-ext-junit = "1.3.0"
+appfunctions = "1.0.0-alpha09"
 com-google-devtools-ksp = "2.3.9"
 compose = "1.12.0-alpha03"
 compose-screenshot = "0.0.1-alpha15"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,15 +39,15 @@ sentry-gradle-plugin = "6.9.0"
 
 [libraries]
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
-appfunctions = { group = "androidx.appfunctions", name = "appfunctions", version.ref = "appfunctions" }
-appfunctions-compiler = { group = "androidx.appfunctions", name = "appfunctions-compiler", version.ref = "appfunctions" }
-appfunctions-service = { group = "androidx.appfunctions", name = "appfunctions-service", version.ref = "appfunctions" }
 android-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
+appfunctions = { group = "androidx.appfunctions", name = "appfunctions", version.ref = "appfunctions" }
+appfunctions-compiler = { group = "androidx.appfunctions", name = "appfunctions-compiler", version.ref = "appfunctions" }
+appfunctions-service = { group = "androidx.appfunctions", name = "appfunctions-service", version.ref = "appfunctions" }
 compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
 compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 activity-compose = "1.13.0"
+appfunctions = "1.0.0-alpha09"
 agp = "9.2.1"
 android-compile-sdk="37"
 android-min-sdk="26"
@@ -38,6 +39,9 @@ sentry-gradle-plugin = "6.9.0"
 
 [libraries]
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+appfunctions = { group = "androidx.appfunctions", name = "appfunctions", version.ref = "appfunctions" }
+appfunctions-compiler = { group = "androidx.appfunctions", name = "appfunctions-compiler", version.ref = "appfunctions" }
+appfunctions-service = { group = "androidx.appfunctions", name = "appfunctions-service", version.ref = "appfunctions" }
 android-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }


### PR DESCRIPTION
## 📝 Description
- Integrates the modern **AppFunctions** API (`androidx.appfunctions:1.0.0-alpha09`) so on-device AI agents like **Gemini** can query visits via natural language (e.g. *"List the visits I have scheduled for today"*).
- Adds a single, extensible `listVisits` AppFunction that returns scheduled visits filtered by date: `today` / `tomorrow` / `past_due` / `done`, or all upcoming pending visits when no filter is given.
- New functions can be added later simply by adding more `@AppFunction` methods to `VisitAppFunctions` — KSP generates the schema and the existing DI wiring picks them up automatically.

### How it works
- `VisitAppFunctions` — `@AppFunction`-annotated entry point backed by `VisitHouseholderRepository`. The `dateFilter` parameter is validated; an unrecognized non-null value throws `AppFunctionInvalidArgumentException` (surfaced to the caller as `AppFunctionException` code 1001) so the agent retries with a documented token instead of receiving silently-wrong data.
- `VisitasApp` — implements `AppFunctionConfiguration.Provider`, supplying the Hilt-injected function instance to the generated service.
- **AndroidManifest** — no manual entries needed; the `appfunctions-service` library auto-injects the service declarations and metadata (pointing at the generated `assets/app_functions.xml`) via manifest merging.

## 🐞 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

### Verification notes
Verified end-to-end on a **Galaxy S23 (Android 16 / SDK 36)** through the OS `AppFunctionManagerService` — the same service Gemini calls:

```
$ adb shell "cmd app_function execute-app-function \
    --package com.msmobile.visitas.debug \
    --function 'com.msmobile.visitas.appfunctions.VisitAppFunctions#listVisits' \
    --parameters '{\"dateFilter\":\"today\"}' --brief-yaml"

androidAppfunctionsReturnValue:
  visits:
    subject: O que é o Reino?
    householderName: Pedro
    scheduledDate: quarta-feira, junho 3 at 10:57 PM
    visitType: FIRST_VISIT
  count: 1
```

The validation/error path was also confirmed: passing `dateFilter="hoje"` returns `AppFunctionException: Unknown dateFilter 'hoje'. Accepted values: today, tomorrow, past_due, done. (code 1001)`.

> **Note:** No automated unit tests are included in this PR; "tests pass locally" refers to the existing suite being unaffected plus the manual on-device verification above. Gemini's live agent calling of AppFunctions is still in private preview (Early Access Program) as of June 2026, so end-to-end agent invocation could not be exercised — only the underlying system-service pathway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)