### PR TITLE
Migrate SettingsScreen to app-level Scaffold

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/AppScaffold.kt
+++ b/app/src/main/java/com/msmobile/visitas/AppScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.DropdownMenu
@@ -54,6 +55,7 @@ fun AppScaffold(
     onEvent: (MainActivityViewModel.UiEvent) -> Unit,
     onNavigateToTab: (DirectionDestinationSpec) -> Unit,
     onNavigate: (Direction) -> Unit,
+    onNavigateUp: () -> Unit = {},
     topBarActions: List<TopBarAction> = emptyList(),
     detailFooterActions: DetailFooterActions? = null,
     content: @Composable () -> Unit
@@ -66,8 +68,10 @@ fun AppScaffold(
         VisitListScreenDestination,
         ConversationListScreenDestination,
         VisitDetailScreenDestination,
-        ConversationDetailScreenDestination
+        ConversationDetailScreenDestination,
+        SettingsScreenDestination
     )
+    val showBackButton = currentDestination == SettingsScreenDestination
     val showBottomNavigation = currentDestination in listOf(
         VisitListScreenDestination,
         ConversationListScreenDestination
@@ -83,6 +87,8 @@ fun AppScaffold(
         ConversationListScreenDestination,
         ConversationDetailScreenDestination -> stringResource(id = R.string.conversations)
 
+        SettingsScreenDestination -> stringResource(id = R.string.settings)
+
         else -> stringResource(id = R.string.app_name)
     }
     Scaffold(
@@ -91,6 +97,16 @@ fun AppScaffold(
                 var menuExpanded by remember { mutableStateOf(false) }
                 TopAppBar(
                     title = { Text(text = title) },
+                    navigationIcon = {
+                        if (showBackButton) {
+                            IconButton(onClick = onNavigateUp) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                    contentDescription = stringResource(id = R.string.navigate_back_content_description)
+                                )
+                            }
+                        }
+                    },
                     actions = {
                         topBarActions.forEach { action ->
                             Box {

--- a/app/src/main/java/com/msmobile/visitas/Main.kt
+++ b/app/src/main/java/com/msmobile/visitas/Main.kt
@@ -38,6 +38,10 @@ fun Main(
     val onNavigate = { direction: Direction ->
         destinationsNavigator.navigate(direction)
     }
+    val onNavigateUp = {
+        destinationsNavigator.navigateUp()
+        Unit
+    }
     VisitasTheme {
         AppScaffold(
             uiState = uiState,
@@ -45,6 +49,7 @@ fun Main(
             onEvent = onEvent,
             onNavigateToTab = onNavigateToTab,
             onNavigate = onNavigate,
+            onNavigateUp = onNavigateUp,
             topBarActions = appScaffoldState.uiState.topBarActions,
             detailFooterActions = appScaffoldState.uiState.detailFooterActions,
             content = {

--- a/app/src/main/java/com/msmobile/visitas/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/settings/SettingsScreen.kt
@@ -10,14 +10,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,7 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.msmobile.visitas.MainActivityViewModel
+import com.msmobile.visitas.BuildConfig
 import com.msmobile.visitas.R
 import com.msmobile.visitas.extension.showShareIntent
 import com.msmobile.visitas.util.DetailScreenStyle
@@ -51,93 +48,92 @@ fun SettingsScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsScreenContent(
     uiState: SettingsDetailViewModel.UiState,
     onEvent: (SettingsDetailViewModel.UiEvent) -> Unit
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(text = stringResource(id = R.string.settings)) }
-            )
-        },
-        content = { paddingValues ->
-            val context = LocalContext.current
-            val createBackupSuccessMessage = stringResource(R.string.create_backup_success)
-            val createBackupFailureMessage = stringResource(R.string.create_backup_failure)
-            val restoreBackupLauncher = rememberRestoreBackupLauncher(onEvent)
+    val context = LocalContext.current
+    val createBackupSuccessMessage = stringResource(R.string.create_backup_success)
+    val createBackupFailureMessage = stringResource(R.string.create_backup_failure)
+    val restoreBackupLauncher = rememberRestoreBackupLauncher(onEvent)
 
-            val backupResult = uiState.backupResult as? SettingsDetailViewModel.BackupResult.BackupCreationSuccess
-            val shareUri = backupResult?.shareFileUri
-            LaunchedEffect(shareUri) {
-                if (shareUri == null) return@LaunchedEffect
-                context.showShareIntent(shareUri, BACKUP_MIME_TYPE)
+    val backupResult = uiState.backupResult as? SettingsDetailViewModel.BackupResult.BackupCreationSuccess
+    val shareUri = backupResult?.shareFileUri
+    LaunchedEffect(shareUri) {
+        if (shareUri == null) return@LaunchedEffect
+        context.showShareIntent(shareUri, BACKUP_MIME_TYPE)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = borderPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = {
+                onEvent(
+                    SettingsDetailViewModel.UiEvent.CreateBackup(
+                        successMessage = createBackupSuccessMessage,
+                        errorMessage = createBackupFailureMessage
+                    )
+                )
             }
+        ) {
+            Text(text = stringResource(R.string.create_backup))
+        }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(horizontal = borderPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Top
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = {
+                restoreBackupLauncher.launch(arrayOf(BACKUP_MIME_TYPE))
+            }
+        ) {
+            Text(text = stringResource(R.string.restore_backup))
+        }
+
+        if (uiState.isLoading) {
+            Spacer(modifier = Modifier.height(16.dp))
+            CircularProgressIndicator()
+        }
+
+        uiState.backupResult?.let { result ->
+            if (result is SettingsDetailViewModel.BackupResult.BackupCreationSuccess) {
+                return@let
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Snackbar(
+                modifier = Modifier.padding(borderPadding),
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
             ) {
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        onEvent(
-                            SettingsDetailViewModel.UiEvent.CreateBackup(
-                                successMessage = createBackupSuccessMessage,
-                                errorMessage = createBackupFailureMessage
-                            )
-                        )
-                    }
-                ) {
-                    Text(text = stringResource(R.string.create_backup))
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        restoreBackupLauncher.launch(arrayOf(BACKUP_MIME_TYPE))
-                    }
-                ) {
-                    Text(text = stringResource(R.string.restore_backup))
-                }
-
-                if (uiState.isLoading) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    CircularProgressIndicator()
-                }
-
-                uiState.backupResult?.let { result ->
-                    if (result is SettingsDetailViewModel.BackupResult.BackupCreationSuccess) {
-                        return@let
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Snackbar(
-                        modifier = Modifier.padding(borderPadding),
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer
-                    ) {
-                        Text(
-                            text = when (result) {
-                                is SettingsDetailViewModel.BackupResult.RestoreFailure -> result.message
-                                is SettingsDetailViewModel.BackupResult.RestoreSuccess -> result.message
-                                is SettingsDetailViewModel.BackupResult.BackupCreationSuccess -> return@Snackbar
-                            },
-                            color = MaterialTheme.colorScheme.onSecondaryContainer
-                        )
-                    }
-                }
+                Text(
+                    text = when (result) {
+                        is SettingsDetailViewModel.BackupResult.RestoreFailure -> result.message
+                        is SettingsDetailViewModel.BackupResult.RestoreSuccess -> result.message
+                        is SettingsDetailViewModel.BackupResult.BackupCreationSuccess -> return@Snackbar
+                    },
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
             }
         }
-    )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Text(
+            text = stringResource(R.string.app_version, BuildConfig.VERSION_NAME),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
 }
 
 @Composable
@@ -160,4 +156,3 @@ private fun rememberRestoreBackupLauncher(
         }
     }
 }
-

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -128,4 +128,6 @@
     <string name="expand_text_content_description">Expandir texto</string>
     <string name="collapse_text_content_description">Contraer texto</string>
     <string name="settings">Configuración</string>
+    <string name="navigate_back_content_description">Volver</string>
+    <string name="app_version">Versión %1$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -127,4 +127,6 @@
     <string name="expand_text_content_description">Expandir texto</string>
     <string name="collapse_text_content_description">Recolher texto</string>
     <string name="settings">Configurações</string>
+    <string name="navigate_back_content_description">Voltar</string>
+    <string name="app_version">Versão %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,4 +129,6 @@
     <string name="expand_text_content_description">Expand text</string>
     <string name="collapse_text_content_description">Collapse text</string>
     <string name="settings">Settings</string>
+    <string name="navigate_back_content_description">Navigate back</string>
+    <string name="app_version">Version %1$s</string>
 </resources>


### PR DESCRIPTION
## 📝 Description
- Remove local `Scaffold`/`TopAppBar` from `SettingsScreen`; all screens now use the single app-level `AppScaffold`
- Add `SettingsScreenDestination` to `showTopBar` and the `title` when block in `AppScaffold.kt`
- Add `showBackButton` flag (currently true only for Settings) that renders a back arrow in the `TopAppBar`
- Wire `onNavigateUp` callback through `Main.kt` using `destinationsNavigator.navigateUp()`
- Switch backup buttons from `Button` to `OutlinedButton` for a more discreet appearance
- Add app version (`BuildConfig.VERSION_NAME`) at the bottom of the Settings screen
- Add `navigate_back_content_description` and `app_version` strings to all three locales (EN, PT-BR, ES)

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions