### PR TITLE
Rework release workflow to manual-only with git tag and GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,6 @@ jobs:
           VERSION_CODE=$(( VERSION_CODE_OFFSET + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
           echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
-          echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
 
@@ -124,7 +123,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-bundle
-          path: |
-            app/build/outputs/bundle/release/*.aab
-            version-code.txt
+          path: app/build/outputs/bundle/release/*.aab
           retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
           VERSION_CODE=$(( VERSION_CODE_OFFSET + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
           echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
+          echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
 
@@ -123,5 +124,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-bundle
-          path: app/build/outputs/bundle/release/*.aab
+          path: |
+            app/build/outputs/bundle/release/*.aab
+            version-code.txt
           retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
 
       - name: Build Release Bundle and Run Tests
-        run: ./gradlew bundleRelease test validateDebugScreenshotTest
+        run: ./gradlew bundleRelease assembleRelease test validateDebugScreenshotTest
         env:
           VERSION_CODE: ${{ steps.version.outputs.code }}
           KEYSTORE_FILE: ${{ github.workspace }}/app/keystore.jks
@@ -125,6 +125,13 @@ jobs:
         with:
           name: app-bundle
           path: app/build/outputs/bundle/release/*.aab
+          retention-days: 30
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-apk
+          path: app/build/outputs/apk/release/*.apk
           retention-days: 30
 
       - name: Upload build info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
           VERSION_CODE=$(( VERSION_CODE_OFFSET + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
           echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
+          echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
 
@@ -125,3 +126,10 @@ jobs:
           name: app-bundle
           path: app/build/outputs/bundle/release/*.aab
           retention-days: 30
+
+      - name: Upload build info
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-info
+          path: version-code.txt
+          retention-days: 400

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,18 +85,21 @@ jobs:
           workflow_conclusion: success
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve version code from build run
+      - name: Download build info
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: build-info
+          path: build-info
+          workflow: build.yml
+          run_id: ${{ steps.download.outputs.run-id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version code
         id: vcode
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUN_ID="${{ steps.download.outputs.run-id }}"
-          RUN_DATA=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID")
-          RUN_NUMBER=$(echo "$RUN_DATA" | jq -r '.run_number')
-          RUN_ATTEMPT=$(echo "$RUN_DATA" | jq -r '.run_attempt')
-          CODE=$(( ${{ vars.VERSION_CODE_OFFSET }} + RUN_NUMBER * 10 + RUN_ATTEMPT ))
+          CODE=$(cat build-info/version-code.txt)
           echo "code=$CODE" >> $GITHUB_OUTPUT
-          echo "Version code: $CODE (build run #$RUN_NUMBER, attempt $RUN_ATTEMPT)"
+          echo "Version code: $CODE"
 
       - name: Create git tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,94 @@
-# Release Pipeline - Deploy to Google Play Store
-# Equivalent to Azure DevOps Release Pipeline
-# Triggered manually or after successful build on master
+# Release Pipeline - Create tag, GitHub release, and deploy to Google Play Store
+# Triggered manually only
 
 name: Release
 
 on:
   workflow_dispatch:
     inputs:
+      version_name:
+        description: 'Version name for the tag (e.g. 1.0.1). Defaults to version.properties.'
+        required: false
+        default: ''
       release_notes:
         description: 'Release notes (Portuguese)'
         required: false
         default: 'Ajustes e melhorias.'
         type: string
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
-    branches:
-      - master
 
 jobs:
   release:
-    name: Deploy to Play Store
+    name: Tag, Release, and Deploy
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
-    # Only run if triggered manually OR if the build workflow succeeded
-    if: >
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      contents: write
 
     steps:
-      # When auto-triggered: download artifact from the build workflow that triggered this
-      - name: Download artifact from build workflow
-        if: github.event_name == 'workflow_run'
-        uses: dawidd6/action-download-artifact@v6
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          name: app-bundle
-          path: artifacts
-          run_id: ${{ github.event.workflow_run.id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
-      # When manually triggered: download latest successful build artifact
+      - name: Resolve version
+        id: version
+        run: |
+          INPUT="${{ inputs.version_name }}"
+          if [ -n "$INPUT" ]; then
+            NAME="$INPUT"
+          else
+            NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          fi
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "tag=v$NAME" >> $GITHUB_OUTPUT
+          echo "Resolved version: $NAME (tag: v$NAME)"
+
+      - name: Verify version bump
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            PREV_VERSION="${PREV_TAG#v}"
+            CURR_VERSION="${{ steps.version.outputs.name }}"
+            if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
+              echo "ERROR: Version has not changed. Current version ($CURR_VERSION) matches the latest tag ($PREV_TAG)."
+              echo "Update versionName in version.properties before releasing."
+              exit 1
+            fi
+            echo "Version bump confirmed: $PREV_VERSION → $CURR_VERSION"
+          else
+            echo "No previous tag found — skipping version check"
+          fi
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog since $PREV_TAG"
+            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
+          else
+            echo "No previous tag found — including all commits"
+            LOG=$(git log --pretty=format:"- %s" --no-merges)
+          fi
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body: ${{ steps.changelog.outputs.content }}
+
       - name: Download latest successful build artifact
-        if: github.event_name == 'workflow_dispatch'
         uses: dawidd6/action-download-artifact@v6
         with:
           name: app-bundle
@@ -59,22 +103,10 @@ jobs:
           echo "Downloaded artifacts:"
           find artifacts -name "*.aab" -type f
 
-
-      - name: Set Release Notes
-        id: release_notes
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            NOTES="${{ inputs.release_notes }}"
-          else
-            NOTES="Ajustes e melhorias."
-          fi
-          echo "notes=$NOTES" >> $GITHUB_OUTPUT
-          echo "Release notes: $NOTES"
-
       - name: Create whatsnew directory
         run: |
           mkdir -p whatsnew
-          echo "${{ steps.release_notes.outputs.notes }}" > whatsnew/whatsnew-pt-BR
+          echo "${{ inputs.release_notes }}" > whatsnew/whatsnew-pt-BR
 
       - name: Deploy to Play Store (Internal Testing)
         uses: r0adkll/upload-google-play@v1
@@ -84,6 +116,6 @@ jobs:
           releaseFiles: artifacts/*.aab
           track: internal
           status: completed
-          releaseName: ${{ github.event_name == 'workflow_dispatch' && inputs.release_notes || 'Automatic Release' }}
+          releaseName: ${{ inputs.release_notes }}
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,24 +101,6 @@ jobs:
           echo "code=$CODE" >> $GITHUB_OUTPUT
           echo "Version code: $CODE"
 
-      - name: Create git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: Release ${{ steps.version.outputs.tag }}
-          body: |
-            ${{ steps.changelog.outputs.content }}
-
-            ---
-            **Build:** `${{ steps.vcode.outputs.code }}`
-
       - name: List artifacts
         run: |
           echo "Downloaded artifacts:"
@@ -140,3 +122,21 @@ jobs:
           releaseName: ${{ inputs.release_notes }}
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body: |
+            ${{ steps.changelog.outputs.content }}
+
+            ---
+            **Build:** `${{ steps.vcode.outputs.code }}`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,15 @@ jobs:
           run_id: ${{ steps.download.outputs.run-id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download APK
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: app-apk
+          path: apk
+          workflow: build.yml
+          run_id: ${{ steps.download.outputs.run-id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Read version code
         id: vcode
         run: |
@@ -123,14 +132,7 @@ jobs:
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
 
-      - name: Create git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
-
-      - name: Create GitHub Release
+      - name: Create git tag and GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
@@ -140,3 +142,4 @@ jobs:
 
             ---
             **Build:** `${{ steps.vcode.outputs.code }}`
+          files: apk/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,23 @@ jobs:
           echo "$LOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Download latest successful build artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: app-bundle
+          path: artifacts
+          workflow: build.yml
+          branch: master
+          workflow_conclusion: success
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version code
+        id: vcode
+        run: |
+          CODE=$(cat artifacts/version-code.txt 2>/dev/null || echo "unknown")
+          echo "code=$CODE" >> $GITHUB_OUTPUT
+          echo "Version code: $CODE"
+
       - name: Create git tag
         run: |
           git config user.name "github-actions[bot]"
@@ -86,17 +103,11 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
-          body: ${{ steps.changelog.outputs.content }}
+          body: |
+            ${{ steps.changelog.outputs.content }}
 
-      - name: Download latest successful build artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          name: app-bundle
-          path: artifacts
-          workflow: build.yml
-          branch: master
-          workflow_conclusion: success
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+            ---
+            **Build:** `${{ steps.vcode.outputs.code }}`
 
       - name: List artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Download latest successful build artifact
+        id: download
         uses: dawidd6/action-download-artifact@v6
         with:
           name: app-bundle
@@ -84,12 +85,18 @@ jobs:
           workflow_conclusion: success
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read version code
+      - name: Resolve version code from build run
         id: vcode
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CODE=$(cat artifacts/version-code.txt 2>/dev/null || echo "unknown")
+          RUN_ID="${{ steps.download.outputs.run-id }}"
+          RUN_DATA=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID")
+          RUN_NUMBER=$(echo "$RUN_DATA" | jq -r '.run_number')
+          RUN_ATTEMPT=$(echo "$RUN_DATA" | jq -r '.run_attempt')
+          CODE=$(( ${{ vars.VERSION_CODE_OFFSET }} + RUN_NUMBER * 10 + RUN_ATTEMPT ))
           echo "code=$CODE" >> $GITHUB_OUTPUT
-          echo "Version code: $CODE"
+          echo "Version code: $CODE (build run #$RUN_NUMBER, attempt $RUN_ATTEMPT)"
 
       - name: Create git tag
         run: |


### PR DESCRIPTION
## 📝 Description

### `release.yml`
- Remove `workflow_run` auto-trigger — release pipeline is now manual-only (`workflow_dispatch`)
- Add optional `version_name` input; falls back to `versionName` in `version.properties`
- Add version bump verification — workflow fails if the semver matches the latest tag
- Generate changelog from commits since the last tag (falls back to all commits on first release)
- Download APK from the same build run and attach it to the GitHub release as a downloadable asset
- Gate git tag and GitHub release on a successful Play Store upload
- Create git tag and GitHub release atomically via `softprops/action-gh-release@v2` (one step, always together)
- Include `VERSION_CODE` in the GitHub release body for build traceability

### `build.yml`
- Add `assembleRelease` alongside `bundleRelease` to produce a signed APK
- Upload APK as `app-apk` artifact (30-day retention)
- Write `VERSION_CODE` to `version-code.txt` and upload as `build-info` artifact (400-day retention) so the exact value is stored in the build run and never needs to be re-derived

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions