### PR TITLE
fix: create release branch via API to trigger release-build.yml

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,5 +1,5 @@
-# Cut Release — creates a release branch from master
-# Pushing the branch automatically triggers release-build.yml
+# Cut Release — creates a release branch from master via GitHub API
+# Branch creation via API (not git push) triggers release-build.yml reliably
 
 name: Cut Release
 
@@ -47,10 +47,14 @@ jobs:
           fi
           echo "Branch $BRANCH does not exist — safe to proceed"
 
-      - name: Create and push release branch
+      - name: Create release branch via API
         run: |
           BRANCH="${{ steps.version.outputs.branch }}"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
-          echo "Release branch $BRANCH created and pushed."
-          echo "release-build.yml will trigger automatically."
+          SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            -X POST \
+            -f ref="refs/heads/${BRANCH}" \
+            -f sha="${SHA}"
+          echo "Release branch ${BRANCH} created at ${SHA}."
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
## 📝 Description
- `cut-release.yml` was creating the release branch via `git push`, which uses credentials from `actions/checkout`. For fine-grained PATs on org-owned repos without explicit org approval, GitHub suppresses workflow triggers for direct git pushes (same behavior as `GITHUB_TOKEN`).
- Switched to creating the branch via the GitHub REST API (`POST /git/refs`) using `WORKFLOW_TOKEN` directly — the same mechanism `branch-sync.yml` uses, which is confirmed to trigger workflow evaluations.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions