### PR TITLE
Repair broken YAML in release-build.yml

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -205,9 +205,7 @@ jobs:
           NEXT_VERSION="${{ steps.versions.outputs.next_version }}"
           BUMP_BRANCH="${{ steps.versions.outputs.bump_branch }}"
           RELEASE_BRANCH="${{ github.ref_name }}"
-          BODY="Automated version bump after cutting \`${RELEASE_BRANCH}\`.
-
-To override with a major bump, edit \`version.properties\` in this PR before merging."
+          BODY=$(printf "Automated version bump after cutting \`%s\`.\n\nTo override with a major bump, edit \`version.properties\` in this PR before merging." "${RELEASE_BRANCH}")
           gh pr create \
             --title "Bump version to ${NEXT_VERSION}" \
             --body "$BODY" \


### PR DESCRIPTION
## 📝 Description
- The `open-version-bump-pr` step had a multi-line bash string where the continuation line (`To override...`) was at column 0, outside the YAML literal block indentation. This made the workflow file unparseable by GitHub Actions.
- Replaced the multi-line assignment with `printf` to keep everything on one properly-indented line.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions