### PR TITLE
Tag the exact built commit, not branch HEAD at deploy time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,13 @@ jobs:
           echo "code=$CODE" >> $GITHUB_OUTPUT
           echo "Version code: $CODE"
 
+      - name: Read build SHA
+        id: sha
+        run: |
+          SHA=$(cat build-info/build-sha.txt)
+          echo "commit=$SHA" >> $GITHUB_OUTPUT
+          echo "Build SHA: $SHA"
+
       - name: List artifacts
         run: |
           echo "Downloaded artifacts:"
@@ -125,6 +132,7 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ steps.sha.outputs.commit }}
           body: |
             ${{ steps.changelog.outputs.content }}
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,6 +84,7 @@ jobs:
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
           echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
           echo "${VERSION_CODE}" > version-code.txt
+          echo "$GITHUB_SHA" > build-sha.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
 
@@ -129,7 +130,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-info
-          path: version-code.txt
+          path: |
+            version-code.txt
+            build-sha.txt
           retention-days: 400
 
   open-version-bump-pr:


### PR DESCRIPTION
Store GITHUB_SHA in build-info artifact during release-build and use target_commitish when creating the GitHub Release, so the tag always points to the commit that was compiled and tested rather than whatever HEAD happens to be on the release branch at deploy time.

## 📝 Description
- Brief description of what this PR does

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions