### PR TITLE
Create release tag at build time, not deploy time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,29 +38,16 @@ jobs:
           echo "tag=v$NAME" >> $GITHUB_OUTPUT
           echo "Version: $NAME (tag: v$NAME)"
 
-      - name: Guard — fail if tag already exists
+      - name: Guard — fail if GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: Tag $TAG already exists. This version has already been released."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release $TAG already exists. This version has already been deployed."
             exit 1
           fi
-          echo "Tag $TAG does not exist — safe to proceed"
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog since $PREV_TAG"
-            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
-          else
-            echo "No previous tag found — including all commits"
-            LOG=$(git log --pretty=format:"- %s" --no-merges)
-          fi
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "No release for $TAG — safe to proceed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download App Bundle from release branch
         id: download
@@ -87,6 +74,15 @@ jobs:
         with:
           name: app-apk
           path: apk
+          workflow: release-build.yml
+          run_id: ${{ steps.download.outputs.run-id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download changelog
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: changelog
+          path: changelog
           workflow: release-build.yml
           run_id: ${{ steps.download.outputs.run-id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +116,15 @@ jobs:
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
 
-      - name: Create git tag and GitHub Release
+      - name: Read changelog
+        id: changelog
+        run: |
+          CONTENT=$(cat changelog/changelog.txt)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -132,6 +132,68 @@ jobs:
           path: version-code.txt
           retention-days: 400
 
+  create-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+
+      - name: Read version
+        id: version
+        run: |
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "tag=v$NAME" >> $GITHUB_OUTPUT
+          echo "Version: $NAME (tag: v$NAME)"
+
+      - name: Guard — fail if tag already exists
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "ERROR: Tag $TAG already exists — this version was already built."
+            exit 1
+          fi
+          echo "Tag $TAG does not exist — safe to proceed"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog since $PREV_TAG"
+            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
+          else
+            echo "No previous tag found — including all commits"
+            LOG=$(git log --pretty=format:"- %s" --no-merges)
+          fi
+          echo "$LOG" > changelog.txt
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Upload changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: changelog.txt
+          retention-days: 400
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "${{ github.sha }}"
+          git push origin "$TAG"
+
   open-version-bump-pr:
     name: Open Version Bump PR on Master
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move tag creation from deploy.yml into a new create-tag job in release-build.yml. The tag is pushed immediately after a successful build, pinned to the exact built commit, so it reflects what was compiled and tested rather than what was deployed.

The changelog is generated before the tag is pushed (so git describe returns the previous tag), uploaded as an artifact, and consumed by deploy.yml to populate the GitHub Release body.

deploy.yml guard updated: fails if a GitHub Release already exists for the tag (replacing the old "fail if tag exists" check, which would now always trigger since the tag is created at build time).

## 📝 Description
- Brief description of what this PR does

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions