### PR TITLE
Fix release/1.2.0 version regression and guard branch/version mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,17 @@ jobs:
           echo "tag=v$NAME" >> $GITHUB_OUTPUT
           echo "Version: $NAME (tag: v$NAME)"
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ inputs.release_branch }}"
+          NAME="${{ steps.version.outputs.name }}"
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Guard — fail if GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,4 +1,4 @@
-# PR Build — debug build + tests for master PRs and master pushes
+# PR Build — debug build + tests for master/release PRs and master pushes
 # Release builds run in release-build.yml on release/** branches
 
 name: PR Build
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'release/**'
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.3.0
+versionName=1.2.0


### PR DESCRIPTION
## 📝 Description
- Restores `versionName=1.2.0` on `release/1.2.0`. PR #164 ("Update README.md") was cut from master instead of the release branch, so its squash-merge silently carried master's `1.3.0` bump (#165) onto `release/1.2.0` — which is why Release Build / Deploy were checking for tag `v1.3.0`.
- Adds a fail-fast guard to `release-build.yml` (before the Gradle build) and `deploy.yml` (before the Play upload): the branch name must equal `release/<versionName>`, otherwise the run aborts with a clear error instead of building/tagging/deploying the wrong version.

## ⚠️ Before merging
Merging this PR pushes to `release/1.2.0` and will retrigger Release Build. **Make sure the `VERSION_CODE_OFFSET` Actions variable is at least `3600` first.** PR #160 renamed `build.yml` → `release-build.yml`, which reset `github.run_number` to 1, so computed version codes regressed below the `3532` already live on the Play internal track — that is what caused the Deploy failure: *"You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs."*

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAy8zhoVJ5ks9AjVJbgbm5)_