### PR TITLE
Port release branch/version guards to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,17 @@ jobs:
           echo "tag=v$NAME" >> $GITHUB_OUTPUT
           echo "Version: $NAME (tag: v$NAME)"
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ inputs.release_branch }}"
+          NAME="${{ steps.version.outputs.name }}"
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Guard — fail if GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## 📝 Description
- Ports the fail-fast guard added on `release/1.2.0` to master so all future `release/X.Y.Z` branches inherit it: `release-build.yml` (before the Gradle build) and `deploy.yml` (before the Play upload) abort with a clear error if the branch name does not equal `release/<versionName>` from `version.properties`.
- Background: PR #164 was cut from master with base `release/1.2.0`, and its squash-merge silently carried master's `1.3.0` version bump onto the release branch — Release Build then tagged/checked `v1.3.0` on `release/1.2.0`. Workflow files run from the branch being built, so the guard must live on master to protect future release branches.
- No version changes in this PR — only the two workflow guard steps.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)