### PR TITLE
Use semver build metadata format for release tags (vX.Y.Z+VERSION_CODE)

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,93 @@
+# Backmerge — keeps master up to date with release branches
+# On every push to release/**, opens (or refreshes) a PR from an
+# intermediate backmerge/* branch into master. Conflict resolution
+# happens on the backmerge branch, never on the release branch.
+
+name: Backmerge
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+concurrency:
+  group: backmerge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backmerge:
+    name: Open Backmerge PR to Master
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+
+      - name: Compute branch names
+        id: names
+        run: |
+          RELEASE_BRANCH="${{ github.ref_name }}"
+          BACKMERGE_BRANCH="backmerge/${RELEASE_BRANCH#release/}"
+          echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+          echo "backmerge_branch=$BACKMERGE_BRANCH" >> $GITHUB_OUTPUT
+          echo "Release: $RELEASE_BRANCH  →  Backmerge: $BACKMERGE_BRANCH"
+
+      - name: Guard — skip if master already has everything
+        id: guard
+        run: |
+          git fetch origin master
+          AHEAD=$(git rev-list --count origin/master..HEAD)
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "Master already contains every commit from ${{ steps.names.outputs.release_branch }} — nothing to backmerge"
+          else
+            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "$AHEAD commit(s) to backmerge"
+          fi
+
+      - name: Create backmerge branch and merge master
+        if: steps.guard.outputs.needed == 'true'
+        id: merge
+        run: |
+          BACKMERGE_BRANCH="${{ steps.names.outputs.backmerge_branch }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BACKMERGE_BRANCH"
+          if git merge origin/master --no-edit; then
+            echo "conflicts=false" >> $GITHUB_OUTPUT
+            echo "Merged master cleanly — PR will be immediately mergeable"
+          else
+            FILES=$(git diff --name-only --diff-filter=U)
+            git merge --abort
+            echo "conflicts=true" >> $GITHUB_OUTPUT
+            echo "files<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "Merge conflicts with master — pushing unmerged head; resolve on $BACKMERGE_BRANCH"
+          fi
+          git push -f origin "$BACKMERGE_BRANCH"
+
+      - name: Open or refresh PR to master
+        if: steps.guard.outputs.needed == 'true'
+        run: |
+          RELEASE_BRANCH="${{ steps.names.outputs.release_branch }}"
+          BACKMERGE_BRANCH="${{ steps.names.outputs.backmerge_branch }}"
+          COUNT=$(gh pr list --head "$BACKMERGE_BRANCH" --base master --state open --json number --jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Backmerge PR already open — the branch push refreshed it"
+            exit 0
+          fi
+          if [ "${{ steps.merge.outputs.conflicts }}" = "true" ]; then
+            TITLE="⚠️ Backmerge ${RELEASE_BRANCH} into master (conflicts)"
+            BODY=$(printf 'Automated backmerge of `%s` into master.\n\n**This branch conflicts with master.** Resolve on `%s` (never on the release branch):\n\n```\ngit fetch origin\ngit checkout %s\ngit merge origin/master   # resolve conflicts, commit\ngit push origin %s\n```\n\nConflicting files:\n```\n%s\n```\n\n> Merge with a **merge commit** (not squash) to preserve ancestry.' "$RELEASE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$CONFLICT_FILES")
+          else
+            TITLE="Backmerge ${RELEASE_BRANCH} into master"
+            BODY=$(printf 'Automated backmerge of `%s` into master. Master was merged into this branch cleanly — no conflicts.\n\n> Merge with a **merge commit** (not squash) to preserve ancestry.' "$RELEASE_BRANCH")
+          fi
+          gh pr create --title "$TITLE" --body "$BODY" --base master --head "$BACKMERGE_BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          CONFLICT_FILES: ${{ steps.merge.outputs.files }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,17 @@ jobs:
           echo "tag=v$NAME" >> $GITHUB_OUTPUT
           echo "Version: $NAME (tag: v$NAME)"
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ inputs.release_branch }}"
+          NAME="${{ steps.version.outputs.name }}"
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Guard — fail if GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,29 +38,16 @@ jobs:
           echo "tag=v$NAME" >> $GITHUB_OUTPUT
           echo "Version: $NAME (tag: v$NAME)"
 
-      - name: Guard — fail if tag already exists
+      - name: Guard — fail if GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: Tag $TAG already exists. This version has already been released."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release $TAG already exists. This version has already been deployed."
             exit 1
           fi
-          echo "Tag $TAG does not exist — safe to proceed"
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog since $PREV_TAG"
-            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
-          else
-            echo "No previous tag found — including all commits"
-            LOG=$(git log --pretty=format:"- %s" --no-merges)
-          fi
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "No release for $TAG — safe to proceed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download App Bundle from release branch
         id: download
@@ -87,6 +74,15 @@ jobs:
         with:
           name: app-apk
           path: apk
+          workflow: release-build.yml
+          run_id: ${{ steps.download.outputs.run-id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download changelog
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: changelog
+          path: changelog
           workflow: release-build.yml
           run_id: ${{ steps.download.outputs.run-id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +116,15 @@ jobs:
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
 
-      - name: Create git tag and GitHub Release
+      - name: Read changelog
+        id: changelog
+        run: |
+          CONTENT=$(cat changelog/changelog.txt)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -157,13 +157,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
+      - name: Download build info
+        uses: actions/download-artifact@v4
+        with:
+          name: build-info
+
       - name: Read version
         id: version
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          VERSION_CODE=$(cat version-code.txt)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "tag=v${NAME}+${VERSION_CODE}" >> $GITHUB_OUTPUT
+          echo "Version: $NAME, code: $VERSION_CODE (tag: v${NAME}+${VERSION_CODE})"
 
       - name: Guard — fail if tag already exists
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Guard — branch must match version.properties
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          if [ "$BRANCH" != "release/${NAME}" ]; then
+            echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
+            echo "A merge likely brought master's version bump into this release branch."
+            exit 1
+          fi
+          echo "Branch $BRANCH matches versionName $NAME"
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -132,6 +132,68 @@ jobs:
           path: version-code.txt
           retention-days: 400
 
+  create-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+
+      - name: Read version
+        id: version
+        run: |
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "tag=v$NAME" >> $GITHUB_OUTPUT
+          echo "Version: $NAME (tag: v$NAME)"
+
+      - name: Guard — fail if tag already exists
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "ERROR: Tag $TAG already exists — this version was already built."
+            exit 1
+          fi
+          echo "Tag $TAG does not exist — safe to proceed"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog since $PREV_TAG"
+            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
+          else
+            echo "No previous tag found — including all commits"
+            LOG=$(git log --pretty=format:"- %s" --no-merges)
+          fi
+          echo "$LOG" > changelog.txt
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Upload changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: changelog.txt
+          retention-days: 400
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "${{ github.sha }}"
+          git push origin "$TAG"
+
   open-version-bump-pr:
     name: Open Version Bump PR on Master
     runs-on: ubuntu-latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ retrofit = "3.0.0"
 room = "2.8.4"
 screenshot-validation-api = "0.0.1-alpha15"
 security-crypto = "1.1.0"
-sentry = "8.43.1"
+sentry = "8.43.2"
 sentry-gradle-plugin = "6.10.0"
 
 [libraries]

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.2.0
+versionName=1.3.0


### PR DESCRIPTION
## 📝 Description
- Changes the release tag format from `vX.Y.Z` to `vX.Y.Z+VERSION_CODE` (semver build metadata)
- Downloads the `build-info` artifact in the `create-tag` job to read the exact version code produced by the build
- Fixes the \"tag already exists\" error that occurs when re-running the workflow for the same version

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions