### PR TITLE
Use semver build metadata format for release tags (vX.Y.Z+VERSION_CODE)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -157,13 +157,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
+      - name: Download build info
+        uses: actions/download-artifact@v4
+        with:
+          name: build-info
+
       - name: Read version
         id: version
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          VERSION_CODE=$(cat version-code.txt)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "tag=v${NAME}+${VERSION_CODE}" >> $GITHUB_OUTPUT
+          echo "Version: $NAME, code: $VERSION_CODE (tag: v${NAME}+${VERSION_CODE})"
 
       - name: Guard — fail if tag already exists
         run: |


### PR DESCRIPTION
## 📝 Description
- Changes the release tag format from `vX.Y.Z` to `vX.Y.Z+VERSION_CODE` (semver build metadata)
- Downloads the `build-info` artifact in the `create-tag` job to read the exact version code produced by the build
- Fixes the \"tag already exists\" error that occurs when re-running the workflow for the same version

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [ ] Follows existing code patterns and conventions