### PR TITLE
Backmerge release/1.2.0 into master

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -157,13 +157,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
+      - name: Download build info
+        uses: actions/download-artifact@v4
+        with:
+          name: build-info
+
       - name: Read version
         id: version
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          VERSION_CODE=$(cat version-code.txt)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "tag=v${NAME}+${VERSION_CODE}" >> $GITHUB_OUTPUT
+          echo "Version: $NAME, code: $VERSION_CODE (tag: v${NAME}+${VERSION_CODE})"
 
       - name: Guard — fail if tag already exists
         run: |


### PR DESCRIPTION
Automated backmerge of `release/1.2.0` into master. Master was merged into this branch cleanly — no conflicts.

> Merge with a **merge commit** (not squash) to preserve ancestry.