### PR TITLE
Generate GitHub Release with auto-generated notes on tag creation

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -211,6 +211,16 @@ jobs:
           git tag "$TAG" "${{ github.sha }}"
           git push origin "$TAG"
 
+      - name: Create GitHub Release
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "v${{ steps.version.outputs.name }}" \
+            --generate-notes \
+            --target "${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+
   open-version-bump-pr:
     name: Open Version Bump PR on Master
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📝 Description
- After a tag is successfully pushed, create a GitHub Release using `gh release create --generate-notes`, which uses GitHub's built-in feature to populate the release body from merged PRs since the last release (grouped by label, with a contributors section)
- The existing `Generate changelog` artifact is kept unchanged for Play Store upload pipelines

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions