### PR TITLE
Decrease artifact retention from 400 to 30 days

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -127,14 +127,14 @@ jobs:
         with:
           name: app-bundle
           path: app/build/outputs/bundle/release/*.aab
-          retention-days: 400
+          retention-days: 30
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: app-apk
           path: app/build/outputs/apk/release/*.apk
-          retention-days: 400
+          retention-days: 30
 
       - name: Record commit SHA
         run: echo "${{ github.sha }}" > commit-sha.txt
@@ -146,7 +146,7 @@ jobs:
           path: |
             version-code.txt
             commit-sha.txt
-          retention-days: 400
+          retention-days: 30
 
   open-version-bump-pr:
     name: Open Version Bump PR on Master


### PR DESCRIPTION
## 📝 Description
- Decrease artifact `retention-days` from 400 to 30 across all workflows
- All occurrences are in `release-build.yml` (app-bundle, app-apk, build-info); no other workflow sets a retention period

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions