### PR TITLE
Backmerge release/1.2.0 into master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 # Play Store Deploy — manual deployment from a release branch
-# Downloads artifacts produced by release-build.yml on the specified branch
+# Downloads artifacts produced by release-build.yml on the specified branch,
+# then tags the deployed commit and creates the GitHub Release
 
 name: Deploy
 
@@ -49,14 +50,18 @@ jobs:
           fi
           echo "Branch $BRANCH matches versionName $NAME"
 
-      - name: Guard — fail if GitHub Release already exists
+      - name: Guard — fail if tag or GitHub Release already exists
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "ERROR: GitHub Release $TAG already exists. This version has already been deployed."
             exit 1
           fi
-          echo "No release for $TAG — safe to proceed"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: Tag $TAG already exists. This version has already been deployed."
+            exit 1
+          fi
+          echo "No tag or release for $TAG — safe to proceed"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -89,21 +94,39 @@ jobs:
           run_id: ${{ steps.download.outputs.run-id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download changelog
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          name: changelog
-          path: changelog
-          workflow: release-build.yml
-          run_id: ${{ steps.download.outputs.run-id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read version code
+      - name: Read build info
         id: vcode
         run: |
           CODE=$(cat build-info/version-code.txt)
+          SHA=$(cat build-info/commit-sha.txt)
           echo "code=$CODE" >> $GITHUB_OUTPUT
-          echo "Version code: $CODE"
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Version code: $CODE (built from commit: $SHA)"
+
+      - name: Guard — built commit must be on the release branch
+        run: |
+          SHA="${{ steps.vcode.outputs.sha }}"
+          if ! git merge-base --is-ancestor "$SHA" HEAD; then
+            echo "ERROR: Built commit $SHA is not on '${{ inputs.release_branch }}'."
+            exit 1
+          fi
+          echo "Built commit $SHA is on '${{ inputs.release_branch }}'"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          SHA="${{ steps.vcode.outputs.sha }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 "$SHA" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog since $PREV_TAG"
+            LOG=$(git log "$PREV_TAG".."$SHA" --pretty=format:"- %s" --no-merges)
+          else
+            echo "No previous tag found — including all commits"
+            LOG=$(git log "$SHA" --pretty=format:"- %s" --no-merges)
+          fi
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: List artifacts
         run: |
@@ -127,18 +150,11 @@ jobs:
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
 
-      - name: Read changelog
-        id: changelog
-        run: |
-          CONTENT=$(cat changelog/changelog.txt)
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ steps.vcode.outputs.sha }}
           name: Release ${{ steps.version.outputs.tag }}
           body: |
             ${{ steps.changelog.outputs.content }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -136,90 +136,17 @@ jobs:
           path: app/build/outputs/apk/release/*.apk
           retention-days: 400
 
+      - name: Record commit SHA
+        run: echo "${{ github.sha }}" > commit-sha.txt
+
       - name: Upload build info
         uses: actions/upload-artifact@v4
         with:
           name: build-info
-          path: version-code.txt
+          path: |
+            version-code.txt
+            commit-sha.txt
           retention-days: 400
-
-  create-tag:
-    name: Create Release Tag
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_TOKEN }}
-
-      - name: Download build info
-        uses: actions/download-artifact@v4
-        with:
-          name: build-info
-
-      - name: Read version
-        id: version
-        run: |
-          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
-          VERSION_CODE=$(cat version-code.txt)
-          echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v${NAME}+${VERSION_CODE}" >> $GITHUB_OUTPUT
-          echo "Version: $NAME, code: $VERSION_CODE (tag: v${NAME}+${VERSION_CODE})"
-
-      - name: Guard — fail if tag already exists
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
-            echo "ERROR: Tag $TAG already exists — this version was already built."
-            exit 1
-          fi
-          echo "Tag $TAG does not exist — safe to proceed"
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog since $PREV_TAG"
-            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
-          else
-            echo "No previous tag found — including all commits"
-            LOG=$(git log --pretty=format:"- %s" --no-merges)
-          fi
-          echo "$LOG" > changelog.txt
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Upload changelog
-        uses: actions/upload-artifact@v4
-        with:
-          name: changelog
-          path: changelog.txt
-          retention-days: 400
-
-      - name: Create and push tag
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG" "${{ github.sha }}"
-          git push origin "$TAG"
-
-      - name: Create GitHub Release
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          gh release create "$TAG" \
-            --title "v${{ steps.version.outputs.name }}" \
-            --generate-notes \
-            --target "${{ github.sha }}"
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
   open-version-bump-pr:
     name: Open Version Bump PR on Master


### PR DESCRIPTION
Automated backmerge of `release/1.2.0` into master. Master was merged into this branch cleanly — no conflicts.

> Merge with a **merge commit** (not squash) to preserve ancestry.