### PR TITLE
Backmerge release/1.2.0 into master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # Play Store Deploy — manual deployment from a release branch
-# Downloads artifacts produced by release-build.yml on the specified branch,
-# then tags the deployed commit and creates the GitHub Release
+# Downloads artifacts produced by release-build.yml on the specified branch
+# (tagging and the GitHub Release happen in release-build.yml)
 
 name: Deploy
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout release branch
@@ -36,8 +36,7 @@ jobs:
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "Version: $NAME"
 
       - name: Guard — branch must match version.properties
         run: |
@@ -49,21 +48,6 @@ jobs:
             exit 1
           fi
           echo "Branch $BRANCH matches versionName $NAME"
-
-      - name: Guard — fail if tag or GitHub Release already exists
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release $TAG already exists. This version has already been deployed."
-            exit 1
-          fi
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "ERROR: Tag $TAG already exists. This version has already been deployed."
-            exit 1
-          fi
-          echo "No tag or release for $TAG — safe to proceed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download App Bundle from release branch
         id: download
@@ -81,15 +65,6 @@ jobs:
         with:
           name: build-info
           path: build-info
-          workflow: release-build.yml
-          run_id: ${{ steps.download.outputs.run-id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download APK
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          name: app-apk
-          path: apk
           workflow: release-build.yml
           run_id: ${{ steps.download.outputs.run-id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,22 +87,6 @@ jobs:
           fi
           echo "Built commit $SHA is on '${{ inputs.release_branch }}'"
 
-      - name: Generate changelog
-        id: changelog
-        run: |
-          SHA="${{ steps.vcode.outputs.sha }}"
-          PREV_TAG=$(git describe --tags --abbrev=0 "$SHA" 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog since $PREV_TAG"
-            LOG=$(git log "$PREV_TAG".."$SHA" --pretty=format:"- %s" --no-merges)
-          else
-            echo "No previous tag found — including all commits"
-            LOG=$(git log "$SHA" --pretty=format:"- %s" --no-merges)
-          fi
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: List artifacts
         run: |
           echo "Downloaded artifacts:"
@@ -149,16 +108,3 @@ jobs:
           releaseName: ${{ inputs.release_notes }}
           whatsNewDirectory: whatsnew
           inAppUpdatePriority: 5
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          target_commitish: ${{ steps.vcode.outputs.sha }}
-          name: Release ${{ steps.version.outputs.tag }}
-          body: |
-            ${{ steps.changelog.outputs.content }}
-
-            ---
-            **Build:** `${{ steps.vcode.outputs.code }}`
-          files: apk/*.apk

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,12 +1,11 @@
-# Release Branch CI — full release build with version code + signing
+# Release Build — manual full release build with version code + signing
+# Tags the built commit and creates the GitHub Release.
 # After a successful build, opens an idempotent version bump PR on master
 
 name: Release Build
 
 on:
-  push:
-    branches:
-      - 'release/**'
+  workflow_dispatch:
 
 concurrency:
   group: release-build-${{ github.ref }}
@@ -16,21 +15,48 @@ jobs:
   build:
     name: Build Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        id: relversion
+        run: |
+          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "tag=v$NAME" >> $GITHUB_OUTPUT
+          echo "Version: $NAME (tag: v$NAME)"
 
       - name: Guard — branch must match version.properties
         run: |
           BRANCH="${{ github.ref_name }}"
-          NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
+          NAME="${{ steps.relversion.outputs.name }}"
           if [ "$BRANCH" != "release/${NAME}" ]; then
             echo "ERROR: Branch '$BRANCH' does not match versionName '$NAME' (expected branch 'release/${NAME}')."
             echo "A merge likely brought master's version bump into this release branch."
             exit 1
           fi
           echo "Branch $BRANCH matches versionName $NAME"
+
+      - name: Guard — fail if tag or GitHub Release already exists
+        run: |
+          TAG="${{ steps.relversion.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release $TAG already exists. This version has already been released."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: Tag $TAG already exists. This version has already been released."
+            exit 1
+          fi
+          echo "No tag or release for $TAG — safe to proceed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -147,6 +173,34 @@ jobs:
             version-code.txt
             commit-sha.txt
           retention-days: 30
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 "${{ github.sha }}" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog since $PREV_TAG"
+            LOG=$(git log "$PREV_TAG".."${{ github.sha }}" --pretty=format:"- %s" --no-merges)
+          else
+            echo "No previous tag found — including all commits"
+            LOG=$(git log "${{ github.sha }}" --pretty=format:"- %s" --no-merges)
+          fi
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.relversion.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: Release ${{ steps.relversion.outputs.tag }}
+          body: |
+            ${{ steps.changelog.outputs.content }}
+
+            ---
+            **Build:** `${{ steps.version.outputs.code }}`
+          files: app/build/outputs/apk/release/*.apk
 
   open-version-bump-pr:
     name: Open Version Bump PR on Master


### PR DESCRIPTION
Automated backmerge of `release/1.2.0` into master. Master was merged into this branch cleanly — no conflicts.

> Merge with a **merge commit** (not squash) to preserve ancestry.