### PR TITLE
Include version code in release tag (vX.Y.Z+VERSION_CODE)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,24 +42,6 @@ jobs:
           fi
           echo "Branch $BRANCH matches versionName $NAME"
 
-      - name: Guard — fail if tag or GitHub Release already exists
-        run: |
-          NAME="${{ steps.relversion.outputs.name }}"
-          # Tags are v<name>+<versionCode>, so match by version prefix (also catches legacy v<name> tags)
-          if [ -n "$(git tag -l "v${NAME}" "v${NAME}+*")" ]; then
-            echo "ERROR: A tag for version ${NAME} already exists. This version has already been released."
-            exit 1
-          fi
-          COUNT=$(gh release list --limit 100 --json tagName \
-            --jq "[.[] | select(.tagName == \"v${NAME}\" or (.tagName | startswith(\"v${NAME}+\")))] | length")
-          if [ "$COUNT" -gt 0 ]; then
-            echo "ERROR: A GitHub Release for version ${NAME} already exists. This version has already been released."
-            exit 1
-          fi
-          echo "No tag or release for version ${NAME} — safe to proceed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -127,6 +109,21 @@ jobs:
           echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
+
+      - name: Guard — fail if tag or GitHub Release already exists
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release $TAG already exists."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: Tag $TAG already exists."
+            exit 1
+          fi
+          echo "No tag or release for $TAG — safe to proceed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Release Bundle and Run Tests
         run: ./gradlew bundleRelease assembleRelease test validateDebugScreenshotTest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "Version: $NAME"
 
       - name: Guard — branch must match version.properties
         run: |
@@ -45,16 +44,19 @@ jobs:
 
       - name: Guard — fail if tag or GitHub Release already exists
         run: |
-          TAG="${{ steps.relversion.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release $TAG already exists. This version has already been released."
+          NAME="${{ steps.relversion.outputs.name }}"
+          # Tags are v<name>+<versionCode>, so match by version prefix (also catches legacy v<name> tags)
+          if [ -n "$(git tag -l "v${NAME}" "v${NAME}+*")" ]; then
+            echo "ERROR: A tag for version ${NAME} already exists. This version has already been released."
             exit 1
           fi
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "ERROR: Tag $TAG already exists. This version has already been released."
+          COUNT=$(gh release list --limit 100 --json tagName \
+            --jq "[.[] | select(.tagName == \"v${NAME}\" or (.tagName | startswith(\"v${NAME}+\")))] | length")
+          if [ "$COUNT" -gt 0 ]; then
+            echo "ERROR: A GitHub Release for version ${NAME} already exists. This version has already been released."
             exit 1
           fi
-          echo "No tag or release for $TAG — safe to proceed"
+          echo "No tag or release for version ${NAME} — safe to proceed"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -118,8 +120,10 @@ jobs:
             exit 1
           fi
           VERSION_CODE=$(( VERSION_CODE_OFFSET + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
+          TAG="v${{ steps.relversion.outputs.name }}+${VERSION_CODE}"
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
-          echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }}) — tag: ${TAG}"
           echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
@@ -192,9 +196,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.relversion.outputs.tag }}
+          tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: ${{ github.sha }}
-          name: Release ${{ steps.relversion.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
           body: |
             ${{ steps.changelog.outputs.content }}
 


### PR DESCRIPTION
## 📝 Description
- Include the version code in the release tag, using the format `vX.Y.Z+VERSION_CODE` (e.g. `v1.2.0+12345`)
- The tag is composed in the "Calculate Version Code" step, since the version code isn't known when the version name is read
- The "tag or Release already exists" guard moved after the version-code calculation and checks only the exact `vX.Y.Z+VERSION_CODE` tag — multiple releases of the same version name (e.g. `v1.2.0+123` then `v1.2.0+456`) are allowed

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions