### PR TITLE
Backmerge release/1.2.0 into master

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           NAME=$(grep '^versionName=' version.properties | cut -d'=' -f2)
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "tag=v$NAME" >> $GITHUB_OUTPUT
-          echo "Version: $NAME (tag: v$NAME)"
+          echo "Version: $NAME"
 
       - name: Guard — branch must match version.properties
         run: |
@@ -42,21 +41,6 @@ jobs:
             exit 1
           fi
           echo "Branch $BRANCH matches versionName $NAME"
-
-      - name: Guard — fail if tag or GitHub Release already exists
-        run: |
-          TAG="${{ steps.relversion.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release $TAG already exists. This version has already been released."
-            exit 1
-          fi
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "ERROR: Tag $TAG already exists. This version has already been released."
-            exit 1
-          fi
-          echo "No tag or release for $TAG — safe to proceed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -118,11 +102,28 @@ jobs:
             exit 1
           fi
           VERSION_CODE=$(( VERSION_CODE_OFFSET + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
+          TAG="v${{ steps.relversion.outputs.name }}+${VERSION_CODE}"
           echo "code=${VERSION_CODE}" >> $GITHUB_OUTPUT
-          echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }})"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Calculated VERSION_CODE: ${VERSION_CODE} (Base: ${VERSION_CODE_OFFSET}, Run: ${{ github.run_number }}, Attempt: ${{ github.run_attempt }}) — tag: ${TAG}"
           echo "${VERSION_CODE}" > version-code.txt
         env:
           VERSION_CODE_OFFSET: ${{ vars.VERSION_CODE_OFFSET }}
+
+      - name: Guard — fail if tag or GitHub Release already exists
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release $TAG already exists."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: Tag $TAG already exists."
+            exit 1
+          fi
+          echo "No tag or release for $TAG — safe to proceed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Release Bundle and Run Tests
         run: ./gradlew bundleRelease assembleRelease test validateDebugScreenshotTest
@@ -192,9 +193,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.relversion.outputs.tag }}
+          tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: ${{ github.sha }}
-          name: Release ${{ steps.relversion.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
           body: |
             ${{ steps.changelog.outputs.content }}
 


### PR DESCRIPTION
Automated backmerge of `release/1.2.0` into master. Master was merged into this branch cleanly — no conflicts.

> Merge with a **merge commit** (not squash) to preserve ancestry.