### PR TITLE
Gate OkHttp body logging on debug builds

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
+++ b/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
@@ -5,6 +5,7 @@ import android.location.Geocoder
 import android.os.Looper
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.msmobile.visitas.BuildConfig
 import com.msmobile.visitas.VisitasDatabase
 import com.msmobile.visitas.conversation.ConversationDao
 import com.msmobile.visitas.conversation.ConversationRepository
@@ -229,9 +230,13 @@ class ApplicationModule {
     @Singleton
     fun provideOkHttpClient(): okhttp3.OkHttpClient {
         return okhttp3.OkHttpClient.Builder()
-            .addInterceptor(okhttp3.logging.HttpLoggingInterceptor().apply {
-                level = okhttp3.logging.HttpLoggingInterceptor.Level.BODY
-            })
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addInterceptor(okhttp3.logging.HttpLoggingInterceptor().apply {
+                        level = okhttp3.logging.HttpLoggingInterceptor.Level.BODY
+                    })
+                }
+            }
             .build()
     }
 


### PR DESCRIPTION
## 📝 Description
- Release builds currently log every OSRM routing request/response body (user coordinates and householder addresses) to logcat because `HttpLoggingInterceptor` is added unconditionally at `Level.BODY`.
- The interceptor is now only added when `BuildConfig.DEBUG` is true; release builds get no logging interceptor at all.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #193

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)