### PR TITLE
Replace summed-hashCode dirty-check with structural snapshot

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
@@ -23,9 +23,11 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             uiState = previewVisitDetailUiState.copy(
                 householder = VisitDetailViewModel.HouseholderState(
                     id = UUID.randomUUID(),
-                    name = "",
-                    address = "",
-                    notes = "",
+                    editable = VisitDetailViewModel.EditableHouseholderData(
+                        name = "",
+                        address = "",
+                        notes = "",
+                    ),
                     showClearName = false,
                     showCopyData = true,
                     addressState = VisitDetailViewModel.HouseholderAddressState.LoadLocation,
@@ -56,7 +58,7 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             householderId = null,
             uiState = previewVisitDetailUiState.copy(
                 householder = previewVisitDetailUiState.householder.copy(
-                    address = "",
+                    editable = previewVisitDetailUiState.householder.editable.copy(address = ""),
                     isLoadingAddress = true
                 )
             ),
@@ -81,7 +83,7 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             uiState = previewVisitDetailUiState.copy(
                 visitList = listOf(
                     previewFirstVisitUiState.copy(
-                        isDone = true,
+                        editable = previewFirstVisitUiState.editable.copy(isDone = true),
                         canBeRemoved = false,
                         nextConversationSuggestion = previewConversationSuggestion,
                         showNextVisitSuggestion = true
@@ -96,12 +98,14 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             householderId = UUID.randomUUID(),
             uiState = previewVisitDetailUiState.copy(
                 householder = previewVisitDetailUiState.householder.copy(
-                    preferredDay = VisitPreferredDay.SATURDAY,
-                    preferredTime = VisitPreferredTime.AFTERNOON
+                    editable = previewVisitDetailUiState.householder.editable.copy(
+                        preferredDay = VisitPreferredDay.SATURDAY,
+                        preferredTime = VisitPreferredTime.AFTERNOON
+                    )
                 ),
                 visitList = listOf(
                     previewFirstVisitUiState.copy(
-                        isDone = false,
+                        editable = previewFirstVisitUiState.editable.copy(isDone = false),
                         canBeRemoved = false,
                         hasVisitTimeError = true
                     )
@@ -116,7 +120,9 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             householderId = UUID.randomUUID(),
             uiState = previewVisitDetailUiState.copy(
                 householder = previewVisitDetailUiState.householder.copy(
-                    notes = "Receptive householder, prefers morning visits. Interested in studying the Bible.",
+                    editable = previewVisitDetailUiState.householder.editable.copy(
+                        notes = "Receptive householder, prefers morning visits. Interested in studying the Bible.",
+                    ),
                     showClearNotes = true,
                     isNotesExpanded = true
                 ),
@@ -130,7 +136,9 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             householderId = UUID.randomUUID(),
             uiState = previewVisitDetailUiState.copy(
                 householder = previewVisitDetailUiState.householder.copy(
-                    notes = "Receptive householder, prefers morning visits. Interested in studying the Bible.",
+                    editable = previewVisitDetailUiState.householder.editable.copy(
+                        notes = "Receptive householder, prefers morning visits. Interested in studying the Bible.",
+                    ),
                     showClearNotes = false,
                     isNotesExpanded = true
                 ),
@@ -154,7 +162,9 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
             householderId = UUID.randomUUID(),
             uiState = previewVisitDetailUiState.copy(
                 householder = previewVisitDetailUiState.householder.copy(
-                    notes = "Receptive householder, prefers morning visits.\nInterested in studying the Bible.",
+                    editable = previewVisitDetailUiState.householder.editable.copy(
+                        notes = "Receptive householder, prefers morning visits.\nInterested in studying the Bible.",
+                    ),
                     showClearNotes = false,
                     isNotesExpanded = false
                 ),
@@ -205,21 +215,23 @@ private val previewMainActivityUiState = MainActivityViewModel.UiState(
 
 private val previewNewVisitUiState = VisitDetailViewModel.VisitState(
     id = UUID.randomUUID(),
-    subject = "",
-    date = previewDate1,
-    isDone = false,
-    householderId = UUID.randomUUID(),
-    canBeRemoved = false,
-    orderIndex = 0,
-    isConversationListExpanded = false,
-    isVisitTypeListExpanded = false,
-    visitType =  VisitDetailViewModel.VisitTypeState(
-        type = VisitType.FIRST_VISIT,
-        description = StringResource(
-            textResId = R.string.first_visit,
-            arguments = listOf()
+    editable = VisitDetailViewModel.EditableVisitData(
+        subject = "",
+        date = previewDate1,
+        isDone = false,
+        orderIndex = 0,
+        visitType = VisitDetailViewModel.VisitTypeState(
+            type = VisitType.FIRST_VISIT,
+            description = StringResource(
+                textResId = R.string.first_visit,
+                arguments = listOf()
+            )
         )
     ),
+    householderId = UUID.randomUUID(),
+    canBeRemoved = false,
+    isConversationListExpanded = false,
+    isVisitTypeListExpanded = false,
     nextConversationSuggestion = null,
     showNextVisitSuggestion = false,
     showClearSubject = false,
@@ -229,21 +241,23 @@ private val previewNewVisitUiState = VisitDetailViewModel.VisitState(
 
 private val previewFirstVisitUiState = VisitDetailViewModel.VisitState(
     id = UUID.randomUUID(),
-    subject = "What is God's Kingdom?",
-    date = previewDate1,
-    isDone = true,
-    householderId = UUID.randomUUID(),
-    canBeRemoved = true,
-    orderIndex = 0,
-    isConversationListExpanded = false,
-    isVisitTypeListExpanded = false,
-    visitType = VisitDetailViewModel.VisitTypeState(
-        type = VisitType.FIRST_VISIT,
-        description = StringResource(
-            textResId = R.string.first_visit,
-            arguments = listOf()
+    editable = VisitDetailViewModel.EditableVisitData(
+        subject = "What is God's Kingdom?",
+        date = previewDate1,
+        isDone = true,
+        orderIndex = 0,
+        visitType = VisitDetailViewModel.VisitTypeState(
+            type = VisitType.FIRST_VISIT,
+            description = StringResource(
+                textResId = R.string.first_visit,
+                arguments = listOf()
+            )
         )
     ),
+    householderId = UUID.randomUUID(),
+    canBeRemoved = true,
+    isConversationListExpanded = false,
+    isVisitTypeListExpanded = false,
     nextConversationSuggestion = null,
     showNextVisitSuggestion = false,
     showClearSubject = false,
@@ -253,21 +267,23 @@ private val previewFirstVisitUiState = VisitDetailViewModel.VisitState(
 
 private val previewReturnVisit = VisitDetailViewModel.VisitState(
     id = UUID.randomUUID(),
-    subject = "Who is the King of God's Kingdom?",
-    date = previewDate2,
-    isDone = false,
-    householderId = UUID.randomUUID(),
-    canBeRemoved = false,
-    orderIndex = 0,
-    isConversationListExpanded = false,
-    isVisitTypeListExpanded = false,
-    visitType = VisitDetailViewModel.VisitTypeState(
-        type = VisitType.RETURN_VISIT,
-        description = StringResource(
-            textResId = R.string.return_visit,
-            arguments = listOf()
+    editable = VisitDetailViewModel.EditableVisitData(
+        subject = "Who is the King of God's Kingdom?",
+        date = previewDate2,
+        isDone = false,
+        orderIndex = 0,
+        visitType = VisitDetailViewModel.VisitTypeState(
+            type = VisitType.RETURN_VISIT,
+            description = StringResource(
+                textResId = R.string.return_visit,
+                arguments = listOf()
+            )
         )
     ),
+    householderId = UUID.randomUUID(),
+    canBeRemoved = false,
+    isConversationListExpanded = false,
+    isVisitTypeListExpanded = false,
     nextConversationSuggestion = null,
     showNextVisitSuggestion = false,
     showClearSubject = false,
@@ -287,9 +303,11 @@ private val previewConversationSuggestion = VisitDetailViewModel.ConversationSta
 private val previewVisitDetailUiState = VisitDetailViewModel.UiState(
     householder = VisitDetailViewModel.HouseholderState(
         id = UUID.randomUUID(),
-    name = "Pedro",
-    address = "Rua 1",
-    notes = "Receptive householder",
+        editable = VisitDetailViewModel.EditableHouseholderData(
+            name = "Pedro",
+            address = "Rua 1",
+            notes = "Receptive householder",
+        ),
         showClearName = true,
         showCopyData = false,
         addressState = VisitDetailViewModel.HouseholderAddressState.LoadLocation,

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
@@ -87,7 +87,7 @@ internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<Visit
                         canBeRemoved = false,
                         nextConversationSuggestion = previewConversationSuggestion,
                         showNextVisitSuggestion = true
-                    ).copy(),
+                    ),
                 )
             ),
             isDarkMode = false

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -345,10 +345,11 @@ private fun HouseholderDetail(
     }
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val notesHasOverflow = remember(householder.notes, constraints.maxWidth, textStyle) {
-            if (householder.notes.isNullOrEmpty()) false
+            val notes = householder.notes
+            if (notes.isNullOrEmpty()) false
             else {
                 val result = textMeasurer.measure(
-                    text = householder.notes,
+                    text = notes,
                     style = textStyle,
                     constraints = constraints,
                     maxLines = 1,

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -48,7 +48,7 @@ class VisitDetailViewModel
 ) : ViewModel() {
     private val didEditableDataChange: Boolean
         get() {
-            return _uiState.value.getEditableDataHash() != initialEditableDataHash
+            return _uiState.value.getEditableDataSnapshot() != initialEditableData
         }
     private val _uiState = MutableStateFlow(
         UiState(
@@ -61,7 +61,7 @@ class VisitDetailViewModel
     )
     private var visits: List<Visit> = listOf()
     private var conversations: List<Conversation> = listOf()
-    private var initialEditableDataHash: Int? = null
+    private var initialEditableData: EditableDataSnapshot? = null
     private var loadAddressAfterPermission = false
     private var isUpdatingVisit: Boolean = false
     private var isAddressFieldFocused: Boolean = false
@@ -997,7 +997,7 @@ class VisitDetailViewModel
             val conversationList = conversations.map { conversation ->
                 conversation.asState
             }
-            val isRecreatingView = initialEditableDataHash != null
+            val isRecreatingView = initialEditableData != null
             if (isRecreatingView) {
                 newState {
                     copy(conversationList = conversationList)
@@ -1040,7 +1040,7 @@ class VisitDetailViewModel
                     )
                 }
             }
-            initialEditableDataHash = _uiState.value.getEditableDataHash()
+            initialEditableData = _uiState.value.getEditableDataSnapshot()
         }
     }
 
@@ -1226,23 +1226,25 @@ class VisitDetailViewModel
             .mapIndexed { index, visit -> visit.copy(orderIndex = index) }
     }
 
-    private fun UiState.getEditableDataHash(): Int {
-        val householderDataHash = householder.name.hashCode() +
-                householder.address.hashCode() +
-                householder.notes.hashCode() +
-                householder.addressLatitude.hashCode() +
-                householder.addressLongitude.hashCode() +
-                householder.preferredDay.hashCode() +
-                householder.preferredTime.hashCode()
-
-        val visitDataHash = visitList.sumOf { visit ->
-            visit.subject.hashCode() +
-                    visit.date.hashCode() +
-                    visit.isDone.hashCode() +
-                    visit.orderIndex.hashCode() +
-                    visit.visitType.hashCode()
-        }
-        return householderDataHash + visitDataHash
+    private fun UiState.getEditableDataSnapshot(): EditableDataSnapshot {
+        return EditableDataSnapshot(
+            householderName = householder.name,
+            householderAddress = householder.address,
+            householderNotes = householder.notes,
+            addressLatitude = householder.addressLatitude,
+            addressLongitude = householder.addressLongitude,
+            preferredDay = householder.preferredDay,
+            preferredTime = householder.preferredTime,
+            visits = visitList.map { visit ->
+                EditableVisitSnapshot(
+                    subject = visit.subject,
+                    date = visit.date,
+                    isDone = visit.isDone,
+                    orderIndex = visit.orderIndex,
+                    visitType = visit.visitType
+                )
+            }
+        )
     }
 
     private fun newState(block: UiState.() -> UiState) {
@@ -1312,6 +1314,25 @@ class VisitDetailViewModel
     )
 
     data class VisitTypeState(val type: VisitType, val description: StringResource)
+
+    private data class EditableDataSnapshot(
+        val householderName: String,
+        val householderAddress: String,
+        val householderNotes: String?,
+        val addressLatitude: Double?,
+        val addressLongitude: Double?,
+        val preferredDay: VisitPreferredDay,
+        val preferredTime: VisitPreferredTime,
+        val visits: List<EditableVisitSnapshot>
+    )
+
+    private data class EditableVisitSnapshot(
+        val subject: String,
+        val date: LocalDateTime,
+        val isDone: Boolean,
+        val orderIndex: Int,
+        val visitType: VisitTypeState
+    )
 
     sealed class UiEvent {
         data class ViewCreated(val householderId: UUID?) : UiEvent()

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -213,9 +213,11 @@ class VisitDetailViewModel
         newState {
             copy(
                 householder = householder.copy(
-                    isLoadingAddress = true,
-                    addressLatitude = latLong.latitude,
-                    addressLongitude = latLong.longitude
+                    editable = householder.editable.copy(
+                        addressLatitude = latLong.latitude,
+                        addressLongitude = latLong.longitude
+                    ),
+                    isLoadingAddress = true
                 ),
                 eventState = UiEventState.Idle
             )
@@ -241,7 +243,7 @@ class VisitDetailViewModel
                         )
                         copy(
                             householder = householder.copy(
-                                address = addressInfo.address,
+                                editable = householder.editable.copy(address = addressInfo.address),
                                 isLoadingAddress = false,
                                 addressState = addressState
                             ),
@@ -277,9 +279,11 @@ class VisitDetailViewModel
                         )
                         copy(
                             householder = householder.copy(
-                                address = addressInfo.address,
-                                addressLatitude = addressInfo.latitude,
-                                addressLongitude = addressInfo.longitude,
+                                editable = householder.editable.copy(
+                                    address = addressInfo.address,
+                                    addressLatitude = addressInfo.latitude,
+                                    addressLongitude = addressInfo.longitude
+                                ),
                                 isLoadingAddress = false,
                                 addressState = addressState
                             ),
@@ -432,8 +436,10 @@ class VisitDetailViewModel
         newState {
             copy(
                 householder = householder.copy(
-                    addressLatitude = null,
-                    addressLongitude = null
+                    editable = householder.editable.copy(
+                        addressLatitude = null,
+                        addressLongitude = null
+                    )
                 )
             )
         }
@@ -468,9 +474,9 @@ class VisitDetailViewModel
                 set(
                     this@apply.indexOfById(visit),
                     visit.copy(
+                        editable = visit.editable.copy(isDone = true),
                         nextConversationSuggestion = null,
-                        showNextVisitSuggestion = false,
-                        isDone = true
+                        showNextVisitSuggestion = false
                     )
                 )
             }
@@ -485,9 +491,12 @@ class VisitDetailViewModel
             val hasNextConversationSuggestion = nextConversationSuggestion != null
             val showNextVisitSuggestion = hasNextConversationSuggestion && !showClearSubject
             val newVisitOrderIndex = updatedList.nextOrderIndex()
-            val newVisit = newVisit(newVisitOrderIndex).copy(
-                visitType = newVisitType,
-                subject = nextSubject,
+            val baseVisit = newVisit(newVisitOrderIndex)
+            val newVisit = baseVisit.copy(
+                editable = baseVisit.editable.copy(
+                    visitType = newVisitType,
+                    subject = nextSubject
+                ),
                 nextConversationSuggestion = nextConversationSuggestion,
                 showNextVisitSuggestion = showNextVisitSuggestion
             )
@@ -531,7 +540,7 @@ class VisitDetailViewModel
                 set(
                     this@apply.indexOfById(visit),
                     visit.copy(
-                        visitType = visitType,
+                        editable = visit.editable.copy(visitType = visitType),
                         isVisitTypeListExpanded = false
                     )
                 )
@@ -548,9 +557,12 @@ class VisitDetailViewModel
             val nextVisitDate = visitList.determineNextVisitDate()
             val nextVisitType = visitList.determineNextVisitType().asState
             val nextOrderIndex = visitList.nextOrderIndex()
-            val nextVisit = newVisit(nextOrderIndex).copy(
-                visitType = nextVisitType,
-                date = nextVisitDate
+            val baseVisit = newVisit(nextOrderIndex)
+            val nextVisit = baseVisit.copy(
+                editable = baseVisit.editable.copy(
+                    visitType = nextVisitType,
+                    date = nextVisitDate
+                )
             )
             val updatedVisitList = listOf(nextVisit)
                 .plus(visitList)
@@ -594,7 +606,7 @@ class VisitDetailViewModel
                 set(
                     this@apply.indexOfById(visit),
                     visit.copy(
-                        subject = value,
+                        editable = visit.editable.copy(subject = value),
                         isConversationListExpanded = isConversionListExpanded,
                         showClearSubject = showClearSubject,
                         showNextVisitSuggestion = showNextVisitSuggestion,
@@ -616,7 +628,7 @@ class VisitDetailViewModel
                 set(
                     this@apply.indexOfById(visit),
                     visit.copy(
-                        isDone = value
+                        editable = visit.editable.copy(isDone = value)
                     )
                 )
             }.revalidatePendingVisits(householder)
@@ -632,7 +644,7 @@ class VisitDetailViewModel
             val updatedList = visitList.toMutableList().apply {
                 set(
                     this@apply.indexOfById(visit),
-                    visit.copy(date = dateTime)
+                    visit.copy(editable = visit.editable.copy(date = dateTime))
                 )
             }.revalidatePendingVisits(householder)
             copy(
@@ -715,7 +727,7 @@ class VisitDetailViewModel
             }
             val visitIndex = updatedList.indexOfById(visit)
             updatedList[visitIndex] = visit.copy(
-                subject = visitSubject,
+                editable = visit.editable.copy(subject = visitSubject),
                 isConversationListExpanded = false,
                 nextConversationSuggestion = nextConversationSuggestion,
                 showNextVisitSuggestion = showNextVisitSuggestion,
@@ -867,7 +879,10 @@ class VisitDetailViewModel
         newState {
             val showClearName = value.isNotEmpty()
             copy(
-                householder = householder.copy(name = value, showClearName = showClearName),
+                householder = householder.copy(
+                    editable = householder.editable.copy(name = value),
+                    showClearName = showClearName
+                ),
                 eventState = UiEventState.Idle
             )
         }
@@ -878,7 +893,7 @@ class VisitDetailViewModel
             val addressState = resolveAddressState(address = value, hasFocus = true)
             copy(
                 householder = householder.copy(
-                    address = value,
+                    editable = householder.editable.copy(address = value),
                     addressState = addressState
                 ),
                 eventState = UiEventState.Idle
@@ -891,7 +906,7 @@ class VisitDetailViewModel
             val showClearNotes = value.isNotEmpty()
             copy(
                 householder = householder.copy(
-                    notes = value,
+                    editable = householder.editable.copy(notes = value),
                     showClearNotes = showClearNotes
                 ),
                 eventState = UiEventState.Idle
@@ -901,7 +916,8 @@ class VisitDetailViewModel
 
     private fun preferredDayChanged(value: VisitPreferredDay) {
         newState {
-            val updatedHouseholder = householder.copy(preferredDay = value)
+            val updatedHouseholder =
+                householder.copy(editable = householder.editable.copy(preferredDay = value))
             copy(
                 householder = updatedHouseholder,
                 visitList = visitList.revalidatePendingVisits(updatedHouseholder),
@@ -912,7 +928,8 @@ class VisitDetailViewModel
 
     private fun preferredTimeChanged(value: VisitPreferredTime) {
         newState {
-            val updatedHouseholder = householder.copy(preferredTime = value)
+            val updatedHouseholder =
+                householder.copy(editable = householder.editable.copy(preferredTime = value))
             copy(
                 householder = updatedHouseholder,
                 visitList = visitList.revalidatePendingVisits(updatedHouseholder),
@@ -949,9 +966,11 @@ class VisitDetailViewModel
     private fun newHouseholder(): HouseholderState {
         return HouseholderState(
             id = idProvider.generateId(),
-            name = "",
-            address = "",
-            notes = null,
+            editable = EditableHouseholderData(
+                name = "",
+                address = "",
+                notes = null
+            ),
             showClearName = false,
             isNotesExpanded = false,
             addressState = HouseholderAddressState.LoadLocation,
@@ -964,15 +983,17 @@ class VisitDetailViewModel
     private fun newVisit(orderIndex: Int): VisitState {
         return VisitState(
             id = idProvider.generateId(),
-            subject = "",
-            date = dateTimeProvider.nowLocalDateTime(),
-            isDone = false,
+            editable = EditableVisitData(
+                subject = "",
+                date = dateTimeProvider.nowLocalDateTime(),
+                isDone = false,
+                orderIndex = orderIndex,
+                visitType = VisitType.FIRST_VISIT.asState
+            ),
             householderId = null,
             canBeRemoved = isAllowedRemoveVisit(orderIndex),
-            orderIndex = orderIndex,
             isConversationListExpanded = false,
             isVisitTypeListExpanded = false,
-            visitType = VisitType.FIRST_VISIT.asState,
             nextConversationSuggestion = null,
             showNextVisitSuggestion = false,
             showClearSubject = false,
@@ -1072,15 +1093,17 @@ class VisitDetailViewModel
     private fun Visit.asState(nextConversation: ConversationState?): VisitState {
         return VisitState(
             id = id,
-            subject = subject,
-            date = date,
-            isDone = isDone,
+            editable = EditableVisitData(
+                subject = subject,
+                date = date,
+                isDone = isDone,
+                orderIndex = orderIndex,
+                visitType = visitType.asState
+            ),
             householderId = householderId,
             canBeRemoved = isAllowedRemoveVisit(orderIndex),
-            orderIndex = orderIndex,
             isConversationListExpanded = false,
             isVisitTypeListExpanded = false,
-            visitType = visitType.asState,
             nextConversationSuggestion = nextConversation,
             showNextVisitSuggestion = nextConversation != null,
             showClearSubject = false,
@@ -1112,19 +1135,21 @@ class VisitDetailViewModel
             )
             return HouseholderState(
                 id = id,
-                name = name,
-                address = address,
-                notes = notes,
+                editable = EditableHouseholderData(
+                    name = name,
+                    address = address,
+                    notes = notes,
+                    addressLatitude = addressLatitude,
+                    addressLongitude = addressLongitude,
+                    preferredDay = preferredDay,
+                    preferredTime = preferredTime
+                ),
                 showClearName = false,
                 showCopyData = true,
                 addressState = addressState,
                 showClearNotes = false,
                 isNotesExpanded = false, // Notes collapsed by default; user can expand if needed
-                isLoadingAddress = false,
-                addressLatitude = addressLatitude,
-                addressLongitude = addressLongitude,
-                preferredDay = preferredDay,
-                preferredTime = preferredTime
+                isLoadingAddress = false
             )
         }
 
@@ -1214,27 +1239,15 @@ class VisitDetailViewModel
         // Sort by date descending (newest first) so the most recent visits stay at the top
         // and internal indices match the visible ordering in the UI.
         return sortedByDescending { visit -> visit.date }
-            .mapIndexed { index, visit -> visit.copy(orderIndex = index) }
+            .mapIndexed { index, visit ->
+                visit.copy(editable = visit.editable.copy(orderIndex = index))
+            }
     }
 
     private fun UiState.getEditableDataSnapshot(): EditableDataSnapshot {
         return EditableDataSnapshot(
-            householderName = householder.name,
-            householderAddress = householder.address,
-            householderNotes = householder.notes,
-            addressLatitude = householder.addressLatitude,
-            addressLongitude = householder.addressLongitude,
-            preferredDay = householder.preferredDay,
-            preferredTime = householder.preferredTime,
-            visits = visitList.map { visit ->
-                EditableVisitSnapshot(
-                    subject = visit.subject,
-                    date = visit.date,
-                    isDone = visit.isDone,
-                    orderIndex = visit.orderIndex,
-                    visitType = visit.visitType
-                )
-            }
+            householder = householder.editable,
+            visits = visitList.map { visit -> visit.editable }
         )
     }
 
@@ -1248,15 +1261,11 @@ class VisitDetailViewModel
 
     data class VisitState(
         val id: UUID,
-        val subject: String,
-        val date: LocalDateTime,
-        val isDone: Boolean,
+        val editable: EditableVisitData,
         val householderId: UUID?,
         val canBeRemoved: Boolean,
-        val orderIndex: Int,
         val isConversationListExpanded: Boolean,
         val isVisitTypeListExpanded: Boolean,
-        val visitType: VisitTypeState,
         val nextConversationSuggestion: ConversationState?,
         val showNextVisitSuggestion: Boolean,
         val showClearSubject: Boolean,
@@ -1264,7 +1273,13 @@ class VisitDetailViewModel
         val caretPosition: Int,
         val calendarEventId: Long? = null,
         val hasVisitTimeError: Boolean = false
-    )
+    ) {
+        val subject get() = editable.subject
+        val date get() = editable.date
+        val isDone get() = editable.isDone
+        val orderIndex get() = editable.orderIndex
+        val visitType get() = editable.visitType
+    }
 
     data class ConversationState(
         val id: UUID?,
@@ -1289,40 +1304,46 @@ class VisitDetailViewModel
 
     data class HouseholderState(
         var id: UUID,
-        val name: String,
-        val address: String,
-        val notes: String?,
+        val editable: EditableHouseholderData,
         val showClearName: Boolean,
         val showCopyData: Boolean,
         val addressState: HouseholderAddressState,
         val showClearNotes: Boolean,
         val isLoadingAddress: Boolean,
-        val isNotesExpanded: Boolean,
+        val isNotesExpanded: Boolean
+    ) {
+        val name get() = editable.name
+        val address get() = editable.address
+        val notes get() = editable.notes
+        val addressLatitude get() = editable.addressLatitude
+        val addressLongitude get() = editable.addressLongitude
+        val preferredDay get() = editable.preferredDay
+        val preferredTime get() = editable.preferredTime
+    }
+
+    data class VisitTypeState(val type: VisitType, val description: StringResource)
+
+    data class EditableHouseholderData(
+        val name: String,
+        val address: String,
+        val notes: String?,
         val addressLatitude: Double? = null,
         val addressLongitude: Double? = null,
         val preferredDay: VisitPreferredDay = VisitPreferredDay.ANY,
         val preferredTime: VisitPreferredTime = VisitPreferredTime.ANY
     )
 
-    data class VisitTypeState(val type: VisitType, val description: StringResource)
-
-    private data class EditableDataSnapshot(
-        val householderName: String,
-        val householderAddress: String,
-        val householderNotes: String?,
-        val addressLatitude: Double?,
-        val addressLongitude: Double?,
-        val preferredDay: VisitPreferredDay,
-        val preferredTime: VisitPreferredTime,
-        val visits: List<EditableVisitSnapshot>
-    )
-
-    private data class EditableVisitSnapshot(
+    data class EditableVisitData(
         val subject: String,
         val date: LocalDateTime,
         val isDone: Boolean,
         val orderIndex: Int,
         val visitType: VisitTypeState
+    )
+
+    private data class EditableDataSnapshot(
+        val householder: EditableHouseholderData,
+        val visits: List<EditableVisitData>
     )
 
     sealed class UiEvent {


### PR DESCRIPTION
## 📝 Description
- `VisitDetailViewModel` decided "did the user edit anything?" by summing `hashCode()`s of the editable fields. Addition is commutative and collision-prone, so colliding edits could skip the discard-changes confirmation and silently lose user edits.
- The editable fields are now snapshotted into a small `EditableDataSnapshot` data class on load and compared with `==` (structural equality), removing the collision risk entirely.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #194

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally (`testDebugUnitTest --tests "*VisitDetailViewModel*"`)
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)