### PR TITLE
Fix visit-type dropdown not closing on outside tap

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -842,7 +842,7 @@ private fun LazyItemScope.VisitTypeDropdownList(
             expanded = visit.isVisitTypeListExpanded,
             properties = PopupProperties(focusable = false),
             onDismissRequest = {
-                onEvent(VisitDetailViewModel.UiEvent.ConversationListDismissed(visit))
+                onEvent(VisitDetailViewModel.UiEvent.VisitTypeListDismissed(visit))
             }) {
             Text(
                 modifier = Modifier.padding(horizontalFieldPadding),

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -85,6 +85,7 @@ class VisitDetailViewModel
             is UiEvent.VisitDateAccepted -> visitDateAccepted(uiEvent.visit, uiEvent.dateTime)
             is UiEvent.RemoveVisitClicked -> removeVisitClicked(uiEvent.visit)
             is UiEvent.ConversationListDismissed -> conversationListDismissed(uiEvent.visit)
+            is UiEvent.VisitTypeListDismissed -> visitTypeListDismissed(uiEvent.visit)
             is UiEvent.ConversationSelected -> conversationSelected(
                 uiEvent.visit,
                 uiEvent.conversation,
@@ -737,6 +738,18 @@ class VisitDetailViewModel
         }
     }
 
+    private fun visitTypeListDismissed(visit: VisitState) {
+        newState {
+            val updatedList = visitList.toMutableList().apply {
+                set(this@apply.indexOfById(visit), visit.copy(isVisitTypeListExpanded = false))
+            }
+            copy(
+                visitList = updatedList,
+                eventState = UiEventState.Idle
+            )
+        }
+    }
+
     private fun deleteAccepted() {
         newState {
             copy(
@@ -1349,6 +1362,7 @@ class VisitDetailViewModel
             UiEvent()
 
         data class ConversationListDismissed(val visit: VisitState) : UiEvent()
+        data class VisitTypeListDismissed(val visit: VisitState) : UiEvent()
         data class NextVisitSuggestionAccepted(val visit: VisitState) : UiEvent()
         data class PreferredDayChanged(val value: VisitPreferredDay) : UiEvent()
         data class PreferredTimeChanged(val value: VisitPreferredTime) : UiEvent()

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -798,6 +798,23 @@ class VisitDetailViewModelTest {
         assertFalse(viewModel.uiState.value.visitList.first().hasVisitTimeError)
     }
 
+    @Test
+    fun `onEvent with VisitTypeListDismissed collapses visit type list`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(
+            VisitDetailViewModel.UiEvent.VisitTypeClicked(viewModel.uiState.value.visitList.first())
+        )
+        val expandedVisit = viewModel.uiState.value.visitList.first()
+        assertTrue(expandedVisit.isVisitTypeListExpanded)
+
+        // Act
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitTypeListDismissed(expandedVisit))
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().isVisitTypeListExpanded)
+    }
+
     private fun createViewModel(
         conversationRepositoryRef: MockReferenceHolder<ConversationRepository>? = null,
         householderRepositoryRef: MockReferenceHolder<HouseholderRepository>? = null,


### PR DESCRIPTION
## 📝 Description
- `VisitTypeDropdownList`'s `onDismissRequest` sent `ConversationListDismissed` (a copy-paste from the conversation dropdown), which clears `isConversationListExpanded` — not `isVisitTypeListExpanded` — so tapping outside the visit-type dropdown never closed it.
- Adds a dedicated `VisitTypeListDismissed` event that collapses the visit-type list, wires it into the dropdown's `onDismissRequest`, and adds a regression test.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #195

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally (`testDebugUnitTest --tests "*VisitDetailViewModel*"`)
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)