### PR TITLE
Fix geocoded addresses rendering as 'Main St, null'

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/util/AddressProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/AddressProvider.kt
@@ -236,7 +236,8 @@ class AddressProvider(
         }
     }
 
-    private fun Address.toStreetAddressString(): String = "$thoroughfare, $subThoroughfare"
+    private fun Address.toStreetAddressString(): String =
+        listOfNotNull(thoroughfare, subThoroughfare).joinToString(", ")
 
     sealed class AddressSpecs {
         data object NoData : AddressSpecs()


### PR DESCRIPTION
## 📝 Description
- `AddressProvider.toStreetAddressString()` interpolated `"$thoroughfare, $subThoroughfare"` with no null guard on `subThoroughfare`, which is frequently null (streets without house numbers). The literal string `"Main St, null"` then got saved and displayed as the householder's address.
- The string is now built with `listOfNotNull(thoroughfare, subThoroughfare).joinToString(", ")`, so null parts are omitted.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #196

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)