### PR TITLE
Build AppUpdateManager from application context via DI

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
+++ b/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
@@ -5,6 +5,8 @@ import android.location.Geocoder
 import android.os.Looper
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.msmobile.visitas.BuildConfig
 import com.msmobile.visitas.VisitasDatabase
 import com.msmobile.visitas.conversation.ConversationDao
@@ -172,6 +174,12 @@ class ApplicationModule {
         permissionChecker: PermissionChecker
     ): CalendarEventManager {
         return CalendarEventManager(context, permissionChecker)
+    }
+
+    @Singleton
+    @Provides
+    fun appUpdateManager(@ApplicationContext context: Context): AppUpdateManager {
+        return AppUpdateManagerFactory.create(context)
     }
 
     @Singleton

--- a/app/src/main/java/com/msmobile/visitas/util/InAppUpdateManager.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/InAppUpdateManager.kt
@@ -1,11 +1,9 @@
 package com.msmobile.visitas.util
 
-import android.app.Activity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
-import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
@@ -31,9 +29,9 @@ import javax.inject.Singleton
  * The priority threshold for immediate updates can be configured via [IMMEDIATE_UPDATE_PRIORITY_THRESHOLD].
  */
 @Singleton
-class InAppUpdateManager @Inject constructor() {
-
-    private var appUpdateManager: AppUpdateManager? = null
+class InAppUpdateManager @Inject constructor(
+    private val appUpdateManager: AppUpdateManager
+) {
 
     /**
      * Minimum priority level that triggers an immediate (forced) update.
@@ -45,23 +43,10 @@ class InAppUpdateManager @Inject constructor() {
     }
 
     /**
-     * Initializes the update manager. Must be called before other methods.
-     */
-    fun initialize(activity: Activity) {
-        appUpdateManager = AppUpdateManagerFactory.create(activity)
-    }
-
-    /**
      * Checks for available updates and returns the update state.
      */
     fun checkForUpdate(): Flow<UpdateState> = callbackFlow {
-        val manager = appUpdateManager ?: run {
-            trySend(UpdateState.Error("AppUpdateManager not initialized"))
-            close()
-            return@callbackFlow
-        }
-
-        manager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
             val state = when (appUpdateInfo.updateAvailability()) {
                 UpdateAvailability.UPDATE_AVAILABLE -> {
                     val updateType = determineUpdateType(appUpdateInfo)
@@ -108,9 +93,7 @@ class InAppUpdateManager @Inject constructor() {
         updateType: Int,
         launcher: ActivityResultLauncher<IntentSenderRequest>
     ) {
-        val manager = appUpdateManager ?: return
-
-        manager.startUpdateFlowForResult(
+        appUpdateManager.startUpdateFlowForResult(
             appUpdateInfo,
             launcher,
             AppUpdateOptions.newBuilder(updateType).build()
@@ -122,11 +105,6 @@ class InAppUpdateManager @Inject constructor() {
      * Use this to show download progress and prompt the user to restart when ready.
      */
     fun observeInstallState(): Flow<InstallState> = callbackFlow {
-        val manager = appUpdateManager ?: run {
-            close()
-            return@callbackFlow
-        }
-
         val listener = InstallStateUpdatedListener { state ->
             val installState = when (state.installStatus()) {
                 InstallStatus.DOWNLOADING -> {
@@ -145,10 +123,10 @@ class InAppUpdateManager @Inject constructor() {
             trySend(installState)
         }
 
-        manager.registerListener(listener)
+        appUpdateManager.registerListener(listener)
 
         awaitClose {
-            manager.unregisterListener(listener)
+            appUpdateManager.unregisterListener(listener)
         }
     }
 
@@ -157,7 +135,7 @@ class InAppUpdateManager @Inject constructor() {
      * Call this when the user confirms they want to restart the app.
      */
     fun completeUpdate() {
-        appUpdateManager?.completeUpdate()
+        appUpdateManager.completeUpdate()
     }
 
     /**
@@ -165,7 +143,7 @@ class InAppUpdateManager @Inject constructor() {
      * Call this in onResume to handle cases where user backs out of an immediate update.
      */
     fun checkForStalledUpdate(launcher: ActivityResultLauncher<IntentSenderRequest>) {
-        appUpdateManager?.appUpdateInfo?.addOnSuccessListener { appUpdateInfo ->
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
             if (appUpdateInfo.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
                 // Resume the update if it was an immediate update
                 if (appUpdateInfo.isImmediateUpdateAllowed) {

--- a/app/src/main/java/com/msmobile/visitas/util/MainActivityExtensions.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/MainActivityExtensions.kt
@@ -39,8 +39,6 @@ internal fun MainActivity.initializeInAppUpdates(
     launcher: ActivityResultLauncher<IntentSenderRequest>,
     onUpdateTypeChanged: (Int?) -> Unit
 ) {
-    inAppUpdateManager.initialize(this)
-
     inAppUpdateManager.checkForUpdate()
         .onEach { state ->
             when (state) {


### PR DESCRIPTION
## 📝 Description
- `InAppUpdateManager` (a `@Singleton`) held a nullable `AppUpdateManager` created from an `Activity` in `initialize()`: temporal coupling (silent no-ops if not initialized) plus retention of an Activity-derived object across configuration changes.
- `AppUpdateManager` is now provided from `@ApplicationContext` in `ApplicationModule` and constructor-injected, so it's non-null from construction. `initialize()` and every nullable fallback path are removed. The update-flow launch still gets the Activity per-call via the `ActivityResultLauncher`.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #203

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)