### PR TITLE
Use injected DispatcherProvider instead of hardcoded Dispatchers.IO

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
+++ b/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
@@ -171,9 +171,10 @@ class ApplicationModule {
     fun calendarEventManager(
         @ApplicationContext context: Context,
         permissionChecker: PermissionChecker,
-        logger: Logger
+        logger: Logger,
+        dispatcherProvider: DispatcherProvider
     ): CalendarEventManager {
-        return CalendarEventManager(context, permissionChecker, logger)
+        return CalendarEventManager(context, permissionChecker, logger, dispatcherProvider)
     }
 
     @Singleton

--- a/app/src/main/java/com/msmobile/visitas/util/CalendarEventManager.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/CalendarEventManager.kt
@@ -5,7 +5,6 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.provider.CalendarContract
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.time.LocalDateTime
@@ -15,7 +14,8 @@ import kotlin.coroutines.cancellation.CancellationException
 class CalendarEventManager(
     private val context: Context,
     private val permissionChecker: PermissionChecker,
-    private val logger: Logger
+    private val logger: Logger,
+    private val dispatchers: DispatcherProvider
 ) {
     fun hasCalendarPermission(): Boolean {
         return permissionChecker.hasPermissions(
@@ -32,7 +32,7 @@ class CalendarEventManager(
         duration: Duration = DEFAULT_DURATION,
         isDone: Boolean = false,
         color: Int = DEFAULT_EVENT_COLOR
-    ): Long? = withContext(Dispatchers.IO) {
+    ): Long? = withContext(dispatchers.io) {
         if (!hasCalendarPermission()) {
             return@withContext null
         }
@@ -59,7 +59,7 @@ class CalendarEventManager(
         }
     }
 
-    suspend fun deleteEvent(eventId: Long): Boolean = withContext(Dispatchers.IO) {
+    suspend fun deleteEvent(eventId: Long): Boolean = withContext(dispatchers.io) {
         if (!hasCalendarPermission()) {
             return@withContext false
         }

--- a/app/src/main/java/com/msmobile/visitas/util/InstallerVerification.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/InstallerVerification.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.pm.Signature
 import android.os.Build
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.security.MessageDigest
 import javax.inject.Inject
@@ -13,7 +12,8 @@ import kotlin.coroutines.cancellation.CancellationException
 
 @Singleton
 class InstallerVerification @Inject constructor(
-    private val logger: Logger
+    private val logger: Logger,
+    private val dispatchers: DispatcherProvider
 ) {
 
     /**
@@ -21,7 +21,7 @@ class InstallerVerification @Inject constructor(
      * @param context Application context
      * @return true if the app is from a valid source, false otherwise
      */
-    suspend fun isValidInstallSource(context: Context): Boolean = withContext(Dispatchers.IO) {
+    suspend fun isValidInstallSource(context: Context): Boolean = withContext(dispatchers.io) {
         try {
             // Check installer package name first
             return@withContext isInstalledFromPlayStore(context) && isValidSignature(context)


### PR DESCRIPTION
## 📝 Description
- `CalendarEventManager` and `InstallerVerification` hardcoded `Dispatchers.IO` in `withContext` calls, so tests can't substitute a test dispatcher and `runTest` virtual time doesn't apply.
- Both now receive the DI-registered `DispatcherProvider` and use `dispatchers.io`, matching the convention everywhere else in the codebase (and documented in AGENTS.md).

> **Note:** stacked on #214 (both PRs touch the same constructors/imports). GitHub will retarget this PR to `master` automatically once #214 is merged and its branch deleted.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #206

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally (full `testDebugUnitTest`)
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)