### PR TITLE
Extract SyncVisitCalendarEventUseCase to unify calendar-sync policy

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/util/SyncVisitCalendarEventUseCase.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/SyncVisitCalendarEventUseCase.kt
@@ -1,0 +1,35 @@
+package com.msmobile.visitas.util
+
+import com.msmobile.visitas.visit.VisitType
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SyncVisitCalendarEventUseCase @Inject constructor(
+    private val calendarEventManager: CalendarEventManager
+) {
+    suspend operator fun invoke(
+        calendarEventId: Long?,
+        visitType: VisitType,
+        subject: String,
+        date: LocalDateTime,
+        isDone: Boolean,
+        householderName: String
+    ): Long? {
+        if (!calendarEventManager.hasCalendarPermission()) return calendarEventId
+        if (visitType == VisitType.FIRST_VISIT) return null
+        val title = if (subject.isNotBlank()) {
+            "$householderName - ${subject.lines().firstOrNull() ?: ""}"
+        } else {
+            householderName
+        }
+        return calendarEventManager.saveEvent(
+            eventId = calendarEventId,
+            title = title,
+            description = subject,
+            startTime = date,
+            isDone = isDone
+        )
+    }
+}

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.msmobile.visitas.householder.Householder
 import com.msmobile.visitas.householder.HouseholderRepository
 import com.msmobile.visitas.util.AddressProvider
 import com.msmobile.visitas.util.CalendarEventManager
+import com.msmobile.visitas.util.SyncVisitCalendarEventUseCase
 import com.msmobile.visitas.util.ClipboardHandler
 import com.msmobile.visitas.util.DateTimeProvider
 import com.msmobile.visitas.util.DispatcherProvider
@@ -40,6 +41,7 @@ class VisitDetailViewModel
     private val idProvider: IdProvider,
     private val permissionChecker: PermissionChecker,
     private val calendarEventManager: CalendarEventManager,
+    private val syncVisitCalendarEvent: SyncVisitCalendarEventUseCase,
     private val visitTimeValidator: VisitTimeValidator,
     private val dateTimeProvider: DateTimeProvider,
     private val latLongParser: LatLongParser,
@@ -842,42 +844,18 @@ class VisitDetailViewModel
         visitList: List<VisitState>
     ): List<VisitState> {
         return visitList.map { visitState ->
-            val calendarEventId = syncCalendarEvent(visitState, householderName)
+            val calendarEventId = syncVisitCalendarEvent(
+                calendarEventId = visitState.calendarEventId,
+                visitType = visitState.visitType.type,
+                subject = visitState.subject,
+                date = visitState.date,
+                isDone = visitState.isDone,
+                householderName = householderName
+            )
             val updatedVisitState = visitState.copy(calendarEventId = calendarEventId)
             val visitModel = updatedVisitState.asModel(householderId)
             visitRepository.save(visitModel)
             visitModel.asState(visitState.nextConversationSuggestion)
-        }
-    }
-
-    private suspend fun syncCalendarEvent(
-        visitState: VisitState,
-        householderName: String
-    ): Long? {
-        if (!calendarEventManager.hasCalendarPermission()) {
-            return visitState.calendarEventId
-        }
-
-        if (visitState.visitType.type == VisitType.FIRST_VISIT) {
-            return null
-        }
-
-        val title = buildCalendarEventTitle(householderName, visitState.subject)
-
-        return calendarEventManager.saveEvent(
-            eventId = visitState.calendarEventId,
-            title = title,
-            description = visitState.subject,
-            startTime = visitState.date,
-            isDone = visitState.isDone
-        )
-    }
-
-    private fun buildCalendarEventTitle(householderName: String, subject: String): String {
-        return if (subject.isNotBlank()) {
-            "$householderName - ${subject.lines().firstOrNull() ?: ""}"
-        } else {
-            householderName
         }
     }
 

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.msmobile.visitas.extension.containsAllWords
 import com.msmobile.visitas.preference.PreferenceRepository
 import com.msmobile.visitas.util.AddressProvider
-import com.msmobile.visitas.util.CalendarEventManager
 import com.msmobile.visitas.util.DateTimeProvider
+import com.msmobile.visitas.util.SyncVisitCalendarEventUseCase
 import com.msmobile.visitas.util.DispatcherProvider
 import com.msmobile.visitas.util.PermissionChecker
 import com.msmobile.visitas.util.UserLocationProvider
@@ -50,7 +50,7 @@ constructor(
     private val userLocationProvider: UserLocationProvider,
     private val permissionChecker: PermissionChecker,
     private val osrmRoutingProvider: com.msmobile.visitas.routing.OsrmRoutingProvider,
-    private val calendarEventManager: CalendarEventManager,
+    private val syncVisitCalendarEvent: SyncVisitCalendarEventUseCase,
     private val dateTimeProvider: DateTimeProvider
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(
@@ -253,8 +253,12 @@ constructor(
         }
         viewModelScope.launch(dispatchers.io) {
             val visitModel = visitRepository.getById(visit.visitId).copy(date = date)
-            val calendarEventId = syncCalendarEvent(
-                visitModel = visitModel,
+            val calendarEventId = syncVisitCalendarEvent(
+                calendarEventId = visitModel.calendarEventId,
+                visitType = visitModel.visitType,
+                subject = visitModel.subject,
+                date = visitModel.date,
+                isDone = visitModel.isDone,
                 householderName = visit.householderName
             )
             val updatedVisitModel = visitModel.copy(calendarEventId = calendarEventId)
@@ -427,31 +431,6 @@ constructor(
 
     private fun hasToBeRescheduled(date: LocalDateTime, isDone: Boolean): Boolean {
         return !isDone && date.toLocalDate().isBefore(LocalDate.now())
-    }
-
-    private suspend fun syncCalendarEvent(visitModel: Visit, householderName: String): Long? {
-        if (!calendarEventManager.hasCalendarPermission()) {
-            return visitModel.calendarEventId
-        }
-
-        val title = buildCalendarEventTitle(householderName, visitModel.subject)
-
-        return calendarEventManager.saveEvent(
-            eventId = visitModel.calendarEventId,
-            title = title,
-            description = visitModel.subject,
-            startTime = visitModel.date,
-            isDone = visitModel.isDone
-        )
-    }
-
-    private fun buildCalendarEventTitle(householderName: String, subject: String): String {
-        return if (subject.isNotBlank()) {
-            val subjectPreview = subject.lines().firstOrNull() ?: ""
-            "$householderName - ${subjectPreview}"
-        } else {
-            householderName
-        }
     }
 
     private fun onLocationChanged(location: UserLocationProvider.UserLocation) {

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -6,6 +6,7 @@ import com.msmobile.visitas.householder.Householder
 import com.msmobile.visitas.householder.HouseholderRepository
 import com.msmobile.visitas.util.AddressProvider
 import com.msmobile.visitas.util.CalendarEventManager
+import com.msmobile.visitas.util.SyncVisitCalendarEventUseCase
 import com.msmobile.visitas.util.ClipboardHandler
 import com.msmobile.visitas.util.DateTimeProvider
 import com.msmobile.visitas.util.DispatcherProvider
@@ -861,6 +862,7 @@ class VisitDetailViewModelTest {
         val calendarEventManager = mock<CalendarEventManager> {
             on { hasCalendarPermission() } doReturn false
         }
+        val syncVisitCalendarEvent = mock<SyncVisitCalendarEventUseCase>()
         val visitTimeValidator = mock<VisitTimeValidator> {
             on { isValidVisitTime(any(), any(), any()) } doReturn visitTimeValidResult
         }
@@ -881,6 +883,7 @@ class VisitDetailViewModelTest {
             idProvider = idProvider,
             permissionChecker = permissionChecker,
             calendarEventManager = calendarEventManager,
+            syncVisitCalendarEvent = syncVisitCalendarEvent,
             visitTimeValidator = visitTimeValidator,
             dateTimeProvider = dateTimeProvider,
             latLongParser = latLongParser,

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
@@ -5,7 +5,7 @@ import com.msmobile.visitas.preference.Preference
 import com.msmobile.visitas.preference.PreferenceRepository
 import com.msmobile.visitas.routing.OsrmRoutingProvider
 import com.msmobile.visitas.util.AddressProvider
-import com.msmobile.visitas.util.CalendarEventManager
+import com.msmobile.visitas.util.SyncVisitCalendarEventUseCase
 import com.msmobile.visitas.util.DateTimeProvider
 import com.msmobile.visitas.util.DispatcherProvider
 import com.msmobile.visitas.util.MainDispatcherRule
@@ -398,7 +398,7 @@ class VisitListViewModelTest {
             }
         }
         val osrmRoutingProvider = mock<OsrmRoutingProvider>()
-        val calendarEventManager = mock<CalendarEventManager>()
+        val syncVisitCalendarEvent = mock<SyncVisitCalendarEventUseCase>()
         val dateTimeProvider = mock<DateTimeProvider>()
         val visitMapAdapter = mock<VisitMapAdapter>()
 
@@ -412,7 +412,7 @@ class VisitListViewModelTest {
             userLocationProvider = userLocationProvider,
             permissionChecker = permissionChecker,
             osrmRoutingProvider = osrmRoutingProvider,
-            calendarEventManager = calendarEventManager,
+            syncVisitCalendarEvent = syncVisitCalendarEvent,
             dateTimeProvider = dateTimeProvider
         )
     }


### PR DESCRIPTION
## 📝 Description
- Extracts `SyncVisitCalendarEventUseCase` into `util/` owning the single source of truth for: permission check, FIRST_VISIT guard, title building, and `CalendarEventManager.saveEvent` delegation
- Both `VisitDetailViewModel` and `VisitListViewModel` now call the use case instead of their own private copies
- Deliberately aligns list behavior to match detail: `FIRST_VISIT` visits do **not** create calendar events (the list VM was the diverging copy — it was creating events that the detail screen would immediately discard on edit)
- `CalendarEventManager` is retained in `VisitDetailViewModel` only for `deleteEvent` and the save-dialog permission check; it is removed entirely from `VisitListViewModel`

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

Fixes #198