### PR TITLE
Wrap navigation side-effects in LaunchedEffect in StateHandler

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -875,11 +875,21 @@ private fun StateHandler(
     onNavigateUp: () -> Unit,
     onEvent: (VisitDetailViewModel.UiEvent) -> Unit
 ) {
-    when (val eventState = uiState.eventState) {
+    val eventState = uiState.eventState
+
+    LaunchedEffect(eventState) {
+        when (eventState) {
+            is VisitDetailViewModel.UiEventState.Canceled,
+            is VisitDetailViewModel.UiEventState.SaveSucceeded,
+            is VisitDetailViewModel.UiEventState.Deleted -> onNavigateUp()
+            else -> {}
+        }
+    }
+
+    when (eventState) {
         is VisitDetailViewModel.UiEventState.Canceled,
         is VisitDetailViewModel.UiEventState.SaveSucceeded,
-        is VisitDetailViewModel.UiEventState.Deleted -> onNavigateUp()
-
+        is VisitDetailViewModel.UiEventState.Deleted,
         is VisitDetailViewModel.UiEventState.Idle,
         is VisitDetailViewModel.UiEventState.Saving,
         is VisitDetailViewModel.UiEventState.Deleting,

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -875,21 +875,15 @@ private fun StateHandler(
     onNavigateUp: () -> Unit,
     onEvent: (VisitDetailViewModel.UiEvent) -> Unit
 ) {
-    val eventState = uiState.eventState
-
-    LaunchedEffect(eventState) {
-        when (eventState) {
-            is VisitDetailViewModel.UiEventState.Canceled,
-            is VisitDetailViewModel.UiEventState.SaveSucceeded,
-            is VisitDetailViewModel.UiEventState.Deleted -> onNavigateUp()
-            else -> {}
-        }
-    }
-
-    when (eventState) {
+    when (val eventState = uiState.eventState) {
         is VisitDetailViewModel.UiEventState.Canceled,
         is VisitDetailViewModel.UiEventState.SaveSucceeded,
-        is VisitDetailViewModel.UiEventState.Deleted,
+        is VisitDetailViewModel.UiEventState.Deleted -> {
+            LaunchedEffect(eventState) {
+                onNavigateUp()
+            }
+        }
+
         is VisitDetailViewModel.UiEventState.Idle,
         is VisitDetailViewModel.UiEventState.Saving,
         is VisitDetailViewModel.UiEventState.Deleting,


### PR DESCRIPTION
## 📝 Description
- `StateHandler` in `VisitDetailScreen` was calling `onNavigateUp()` directly inside a `when` during composition for `Canceled`, `SaveSucceeded`, and `Deleted` states
- This is a side-effect running during composition — a double-pop navigation crash vector on recomposition
- Moves the three navigation calls into `LaunchedEffect(eventState)`, which runs them as a coroutine effect exactly once per state transition, after composition

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

Fixes #202