### PR TITLE
Replace direct now()/Locale.getDefault() with injected providers

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/extension/DurationExtensions.kt
+++ b/app/src/main/java/com/msmobile/visitas/extension/DurationExtensions.kt
@@ -3,10 +3,10 @@ package com.msmobile.visitas.extension
 import java.util.Locale
 import kotlin.time.Duration
 
-fun Duration.toClockString(): String {
+fun Duration.toClockString(locale: Locale = Locale.getDefault()): String {
     return toComponents { hours, minutes, seconds, _ ->
         String.format(
-            Locale.getDefault(),
+            locale,
             "%02d:%02d:%02d",
             hours,
             minutes,

--- a/app/src/main/java/com/msmobile/visitas/summary/SummaryViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/summary/SummaryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msmobile.visitas.R
 import com.msmobile.visitas.ui.views.MonthNavigatorEvent
+import com.msmobile.visitas.util.DateTimeProvider
 import com.msmobile.visitas.util.DispatcherProvider
 import com.msmobile.visitas.util.StringResource
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,13 +22,14 @@ class SummaryViewModel
 @Inject
 constructor(
     private val summaryRepository: SummaryRepository,
-    private val dispatchers: DispatcherProvider
+    private val dispatchers: DispatcherProvider,
+    private val dateTimeProvider: DateTimeProvider
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(
         UiState(
             returnVisitCount = "",
             bibleStudyCount = "",
-            selectedMonth = LocalDateTime.now(),
+            selectedMonth = dateTimeProvider.nowLocalDateTime(),
             isSummaryMenuExpanded = false,
             summaryFilterOptions = listOf(),
             shouldShowSummaryDetails = false
@@ -90,7 +92,7 @@ constructor(
 
     private fun goToCurrentMonth() {
         newState {
-            val currentMonth = LocalDateTime.now()
+            val currentMonth = dateTimeProvider.nowLocalDateTime()
             copy(selectedMonth = currentMonth)
         }
         loadSummary(_uiState.value.selectedMonth)

--- a/app/src/main/java/com/msmobile/visitas/ui/views/DateTimePicker.kt
+++ b/app/src/main/java/com/msmobile/visitas/ui/views/DateTimePicker.kt
@@ -51,7 +51,8 @@ private const val TIME_PICKER_TAB = 1
 fun DateTimePicker(
     dateTime: LocalDateTime,
     onDateSelected: (LocalDateTime) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    now: LocalDateTime = LocalDateTime.now()
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
     var selectedDate by remember { mutableStateOf(dateTime) }
@@ -75,7 +76,7 @@ fun DateTimePicker(
         selectedDate = datePickerState.getSelectedDate()?.atTime(
             selectedDate.hour,
             selectedDate.minute
-        ) ?: LocalDateTime.now()
+        ) ?: now
     }
     // Update the selected date when the time picker state changes
     key(timePickerState.hour, timePickerState.minute) {
@@ -132,9 +133,9 @@ fun DateTimePicker(
                 horizontalArrangement = Arrangement.spacedBy(horizontalFieldPadding)
             ) {
                 if (selectedTabIndex == DATE_PICKER_TAB) {
-                    SelectTodayButton(onPresetSelected = onDatePresetSelected)
+                    SelectTodayButton(today = now.toLocalDate(), onPresetSelected = onDatePresetSelected)
                 } else {
-                    SelectNowButton(onPresetSelected = onTimePresetSelected)
+                    SelectNowButton(now = now, onPresetSelected = onTimePresetSelected)
                 }
 
                 TextButton(onClick = onDismiss) {
@@ -204,25 +205,15 @@ private fun DateTimePickerContent(
 }
 
 @Composable
-private fun SelectTodayButton(onPresetSelected: (LocalDate) -> Unit) {
-    OutlinedButton(
-        onClick = {
-            val today = LocalDate.now()
-            onPresetSelected(today)
-        }
-    ) {
+private fun SelectTodayButton(today: LocalDate, onPresetSelected: (LocalDate) -> Unit) {
+    OutlinedButton(onClick = { onPresetSelected(today) }) {
         Text(text = stringResource(id = R.string.date_time_picker_today))
     }
 }
 
 @Composable
-private fun SelectNowButton(onPresetSelected: (LocalDateTime) -> Unit) {
-    OutlinedButton(
-        onClick = {
-            val now = LocalDateTime.now()
-            onPresetSelected(now)
-        }
-    ) {
+private fun SelectNowButton(now: LocalDateTime, onPresetSelected: (LocalDateTime) -> Unit) {
+    OutlinedButton(onClick = { onPresetSelected(now) }) {
         Text(text = stringResource(id = R.string.date_time_picker_now))
     }
 }

--- a/app/src/main/java/com/msmobile/visitas/ui/views/MonthNavigator.kt
+++ b/app/src/main/java/com/msmobile/visitas/ui/views/MonthNavigator.kt
@@ -22,13 +22,14 @@ import java.time.temporal.ChronoUnit
 fun MonthNavigator(
     modifier: Modifier = Modifier,
     dateTime: LocalDateTime,
+    now: LocalDateTime = LocalDateTime.now(),
     onEvent: (MonthNavigatorEvent) -> Unit
 ) {
     val dateFormat = DateTimeFormatter.ofPattern("MMM, yyyy")
     val month = dateFormat.format(dateTime)
     val isNextMonthFutureDate = dateTime
         .plusMonths(1)
-        .truncatedTo(ChronoUnit.DAYS) > LocalDateTime.now().truncatedTo(ChronoUnit.DAYS)
+        .truncatedTo(ChronoUnit.DAYS) > now.truncatedTo(ChronoUnit.DAYS)
     val enableFutureDates = !isNextMonthFutureDate
     Row(
         modifier = modifier,

--- a/app/src/main/java/com/msmobile/visitas/util/DateTimeProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/DateTimeProvider.kt
@@ -1,5 +1,6 @@
 package com.msmobile.visitas.util
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Date
 
@@ -10,6 +11,10 @@ class DateTimeProvider {
 
     fun nowLocalDateTime(): LocalDateTime {
         return LocalDateTime.now()
+    }
+
+    fun nowLocalDate(): LocalDate {
+        return LocalDate.now()
     }
 
     fun nanoTime(): Long {

--- a/app/src/main/java/com/msmobile/visitas/util/VisitDataFormatter.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/VisitDataFormatter.kt
@@ -7,7 +7,9 @@ import java.time.LocalDateTime
 import java.util.Locale
 import javax.inject.Inject
 
-class VisitDataFormatter @Inject constructor() {
+class VisitDataFormatter @Inject constructor(
+    private val localeProvider: LocaleProvider
+) {
     fun format(
         name: String,
         address: String,
@@ -47,7 +49,7 @@ class VisitDataFormatter @Inject constructor() {
             if (nextPendingVisitSubject != null && nextPendingVisitDate != null) {
                 appendLine()
                 appendLine(nextPendingVisitSubject)
-                appendLine(nextPendingVisitDate.toString(Locale.getDefault()))
+                appendLine(nextPendingVisitDate.toString(localeProvider.getLocale()))
             }
         }.trim()
     }

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -61,7 +61,7 @@ constructor(
                 dateFilter = VisitDateFilter.All,
                 distanceFilter = VisitDistanceFilter.All
             ),
-            selectedDate = LocalDateTime.now(),
+            selectedDate = dateTimeProvider.nowLocalDateTime(),
             isVisitsFilterMenuExpanded = false,
             selectedTabIndex = 0,
             visitsFilterOptions = listOf(),
@@ -344,7 +344,7 @@ constructor(
     }
 
     private fun rescheduleVisitTodaySelected(visit: VisitHouseholderState) {
-        val date = LocalDate.now()
+        val date = dateTimeProvider.nowLocalDate()
             .atStartOfDay()
             .withHour(visit.date.hour)
             .withMinute(visit.date.minute)
@@ -352,7 +352,7 @@ constructor(
     }
 
     private fun rescheduleVisitTomorrowSelected(visit: VisitHouseholderState) {
-        val date = LocalDate.now()
+        val date = dateTimeProvider.nowLocalDate()
             .plusDays(1)
             .atStartOfDay()
             .withHour(visit.date.hour)
@@ -361,7 +361,7 @@ constructor(
     }
 
     private fun rescheduleVisitSelected(visit: VisitHouseholderState, dayOfWeek: DayOfWeek) {
-        val date = LocalDate.now()
+        val date = dateTimeProvider.nowLocalDate()
             .with(next(dayOfWeek))
             .atStartOfDay()
             .withHour(visit.date.hour)
@@ -430,7 +430,7 @@ constructor(
     }
 
     private fun hasToBeRescheduled(date: LocalDateTime, isDone: Boolean): Boolean {
-        return !isDone && date.toLocalDate().isBefore(LocalDate.now())
+        return !isDone && date.toLocalDate().isBefore(dateTimeProvider.nowLocalDate())
     }
 
     private fun onLocationChanged(location: UserLocationProvider.UserLocation) {
@@ -644,7 +644,7 @@ constructor(
     }
 
     private fun List<VisitHouseholderState>.filterBy(filter: VisitFilter): List<VisitHouseholderState> {
-        val today = LocalDate.now()
+        val today = dateTimeProvider.nowLocalDate()
         return map { visit ->
             val (search, dateFilter, distanceFilter) = filter
             val householderDistance = visit.householderAddressDistance
@@ -684,7 +684,7 @@ constructor(
 
     private val VisitListDateFilterOption.asDateFilter: VisitDateFilter
         get() {
-            val today = LocalDate.now()
+            val today = dateTimeProvider.nowLocalDate()
             val tomorrow = today.plusDays(1)
             val afterTomorrow = tomorrow.plusDays(1)
             val dateFilter = when (this) {

--- a/app/src/test/java/com/msmobile/visitas/summary/SummaryViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/summary/SummaryViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.msmobile.visitas.summary
 
 import com.msmobile.visitas.ui.views.MonthNavigatorEvent
+import com.msmobile.visitas.util.DateTimeProvider
 import com.msmobile.visitas.util.DispatcherProvider
 import com.msmobile.visitas.util.MainDispatcherRule
 import com.msmobile.visitas.util.MockReferenceHolder
@@ -166,7 +167,8 @@ class SummaryViewModelTest {
 
         return SummaryViewModel(
             summaryRepository = summaryRepository,
-            dispatchers = dispatchers
+            dispatchers = dispatchers,
+            dateTimeProvider = DateTimeProvider()
         )
     }
 

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -14,6 +14,7 @@ import com.msmobile.visitas.util.IdProvider
 import com.msmobile.visitas.util.LatLongParser
 import com.msmobile.visitas.util.MainDispatcherRule
 import com.msmobile.visitas.util.MockReferenceHolder
+import com.msmobile.visitas.util.LocaleProvider
 import com.msmobile.visitas.util.PermissionChecker
 import com.msmobile.visitas.util.VisitDataFormatter
 import junit.framework.TestCase.assertEquals
@@ -871,7 +872,7 @@ class VisitDetailViewModelTest {
         }
         val latLongParser = mock<LatLongParser>()
         val clipboardHandler = mock<ClipboardHandler>()
-        val visitDataFormatter = VisitDataFormatter()
+        val visitDataFormatter = VisitDataFormatter(LocaleProvider())
         clipboardHandlerRef?.value = clipboardHandler
 
         return VisitDetailViewModel(

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verifyBlocking
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -399,7 +400,10 @@ class VisitListViewModelTest {
         }
         val osrmRoutingProvider = mock<OsrmRoutingProvider>()
         val syncVisitCalendarEvent = mock<SyncVisitCalendarEventUseCase>()
-        val dateTimeProvider = mock<DateTimeProvider>()
+        val dateTimeProvider = mock<DateTimeProvider> {
+            on { nowLocalDateTime() } doReturn LocalDateTime.now()
+            on { nowLocalDate() } doReturn LocalDate.now()
+        }
         val visitMapAdapter = mock<VisitMapAdapter>()
 
         return VisitListViewModel(


### PR DESCRIPTION
## 📝 Description
- **`VisitListViewModel`**: all 7 `LocalDate/LocalDateTime.now()` call sites replaced with `dateTimeProvider` — `hasToBeRescheduled`, `filterBy`, `asDateFilter`, `rescheduleVisitToday/Tomorrow/Selected`, and the initial-state `selectedDate` are now time-pinnable in tests
- **`SummaryViewModel`**: inject `DateTimeProvider`; replace both `LocalDateTime.now()` calls in initial state and `goToCurrentMonth()`
- **`DateTimePicker`**: accept `now: LocalDateTime = LocalDateTime.now()` parameter; use it as the fallback when the date picker returns null and as the preset value for "Today"/"Now" buttons — no composition-time clock reads, fully testable
- **`MonthNavigator`**: accept `now: LocalDateTime = LocalDateTime.now()` parameter for the future-month guard that fires during composition
- **`DurationExtensions`**: add `locale: Locale = Locale.getDefault()` parameter to `toClockString()` — no-arg callers unaffected
- **`VisitDataFormatter`**: inject `LocaleProvider`; replace `Locale.getDefault()` in date formatting

All default values preserve existing runtime behavior; no caller changes required for production code.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

Fixes #205