### PR TITLE
Log swallowed exceptions and stop eating CancellationException

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
+++ b/app/src/main/java/com/msmobile/visitas/di/ApplicationModule.kt
@@ -128,12 +128,14 @@ class ApplicationModule {
     @Provides
     fun addressProvider(
         geocoder: Geocoder,
-        locationProviderClient: FusedLocationProviderClient
+        locationProviderClient: FusedLocationProviderClient,
+        logger: Logger
     ): AddressProvider {
         return AddressProvider(
             geocoder = geocoder,
             locationProviderClient = locationProviderClient,
-            looper = Looper.getMainLooper()
+            looper = Looper.getMainLooper(),
+            logger = logger
         )
     }
 
@@ -171,9 +173,10 @@ class ApplicationModule {
     @Provides
     fun calendarEventManager(
         @ApplicationContext context: Context,
-        permissionChecker: PermissionChecker
+        permissionChecker: PermissionChecker,
+        logger: Logger
     ): CalendarEventManager {
-        return CalendarEventManager(context, permissionChecker)
+        return CalendarEventManager(context, permissionChecker, logger)
     }
 
     @Singleton

--- a/app/src/main/java/com/msmobile/visitas/routing/OsrmRoutingProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/routing/OsrmRoutingProvider.kt
@@ -5,6 +5,7 @@ import com.msmobile.visitas.util.Logger
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
@@ -35,6 +36,9 @@ class OsrmRoutingProvider @Inject constructor(
             val routeGeometry = try {
                 getRouteGeometry(currentLocation, orderedVisits)
             } catch (e: Exception) {
+                if (e is CancellationException) {
+                    throw e
+                }
                 logger.error("OSRM", "Failed to get route geometry: ${e.message}", e)
                 null
             }
@@ -44,6 +48,9 @@ class OsrmRoutingProvider @Inject constructor(
                 routeGeometry = routeGeometry
             )
         } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
             logger.error("OSRM", "Error optimizing route: ${e.message}", e)
 
             // Fallback: return visits in original order
@@ -131,6 +138,9 @@ class OsrmRoutingProvider @Inject constructor(
                 null
             }
         } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
             logger.error("OSRM", "Error getting route geometry: ${e.message}", e)
             null
         }

--- a/app/src/main/java/com/msmobile/visitas/util/AddressProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/AddressProvider.kt
@@ -14,11 +14,13 @@ import com.google.android.gms.location.Priority
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
 
 class AddressProvider(
     private val geocoder: Geocoder,
     private val locationProviderClient: FusedLocationProviderClient,
-    private val looper: Looper
+    private val looper: Looper,
+    private val logger: Logger
 ) {
     suspend fun getAddressListFromCurrentLocation(): List<AddressSpecs> {
         // Get location with retries
@@ -67,8 +69,11 @@ class AddressProvider(
                 if (location != null) {
                     return location
                 }
-            } catch (_: Throwable) {
-                // Log error if needed
+            } catch (error: Exception) {
+                if (error is CancellationException) {
+                    throw error
+                }
+                logger.error(TAG, "Failed to get current location", error)
             }
 
             attempts++
@@ -91,8 +96,11 @@ class AddressProvider(
                 if (addresses.isNotEmpty()) {
                     return addresses
                 }
-            } catch (_: Throwable) {
-                // Log error if needed
+            } catch (error: Exception) {
+                if (error is CancellationException) {
+                    throw error
+                }
+                logger.error(TAG, "Failed to get addresses from location", error)
             }
 
             attempts++
@@ -231,7 +239,8 @@ class AddressProvider(
                     longitude = address.longitude
                 )
             }
-        } catch (_: Throwable) {
+        } catch (error: Exception) {
+            logger.error(TAG, "Failed to get address from lat/long", error)
             AddressSpecs.NoData
         }
     }
@@ -256,6 +265,7 @@ class AddressProvider(
     }
 
     private companion object {
+        private const val TAG = "AddressProvider"
         private const val LOCATION_REQUEST_INTERVAL = 3_000L
         private const val MAX_ADDRESS_RESULTS = 10
         private const val LOCATION_ACCURACY = 20

--- a/app/src/main/java/com/msmobile/visitas/util/CalendarEventManager.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/CalendarEventManager.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.ZoneId
+import kotlin.coroutines.cancellation.CancellationException
 
 class CalendarEventManager(
     private val context: Context,
-    private val permissionChecker: PermissionChecker
+    private val permissionChecker: PermissionChecker,
+    private val logger: Logger
 ) {
     fun hasCalendarPermission(): Boolean {
         return permissionChecker.hasPermissions(
@@ -67,6 +69,10 @@ class CalendarEventManager(
             val rowsDeleted = context.contentResolver.delete(uri, null, null)
             rowsDeleted > 0
         } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
+            logger.error(TAG, "Failed to delete calendar event $eventId", e)
             false
         }
     }
@@ -76,6 +82,7 @@ class CalendarEventManager(
             val uri = context.contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
             uri?.lastPathSegment?.toLongOrNull()
         } catch (e: Exception) {
+            logger.error(TAG, "Failed to insert calendar event", e)
             null
         }
     }
@@ -86,6 +93,7 @@ class CalendarEventManager(
             val rowsUpdated = context.contentResolver.update(uri, values, null, null)
             if (rowsUpdated > 0) eventId else null
         } catch (e: Exception) {
+            logger.error(TAG, "Failed to update calendar event $eventId", e)
             null
         }
     }
@@ -165,12 +173,14 @@ class CalendarEventManager(
             )?.use { cursor ->
                 cursor.count > 0
             } ?: false
-        } catch (_: Throwable) {
+        } catch (e: Exception) {
+            logger.error(TAG, "Failed to check if calendar event $eventId exists", e)
             false
         }
     }
 
     companion object {
+        private const val TAG = "CalendarEventManager"
         private const val CHECKMARK = "✅ "
         private const val GOOGLE_ACCOUNT_TYPE = "com.google"
         private val DEFAULT_DURATION: Duration = Duration.ofMinutes(30)

--- a/app/src/main/java/com/msmobile/visitas/util/InstallerVerification.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/InstallerVerification.kt
@@ -9,9 +9,12 @@ import kotlinx.coroutines.withContext
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 @Singleton
-class InstallerVerification @Inject constructor() {
+class InstallerVerification @Inject constructor(
+    private val logger: Logger
+) {
 
     /**
      * Verifies if the app was installed from Google Play Store or is part of internal test
@@ -22,8 +25,12 @@ class InstallerVerification @Inject constructor() {
         try {
             // Check installer package name first
             return@withContext isInstalledFromPlayStore(context) && isValidSignature(context)
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
+            if (error is CancellationException) {
+                throw error
+            }
             // If any error occurs during verification, assume invalid installation
+            logger.error(TAG, "Install source verification failed", error)
             return@withContext false
         }
     }
@@ -84,6 +91,7 @@ class InstallerVerification @Inject constructor() {
             } ?: false
 
         } catch (e: Exception) {
+            logger.error(TAG, "Signature validation failed", e)
             false
         }
     }
@@ -110,7 +118,12 @@ class InstallerVerification @Inject constructor() {
             }
             false
         } catch (e: Exception) {
+            logger.error(TAG, "Signature digest failed", e)
             false
         }
+    }
+
+    private companion object {
+        private const val TAG = "InstallerVerification"
     }
 }


### PR DESCRIPTION
## 📝 Description
- `AddressProvider`, `CalendarEventManager`, and `InstallerVerification` swallowed exceptions silently (some with literal `// Log error if needed` placeholders), leaving nothing to diagnose when geocoding, calendar writes, or install verification fail. They now receive the existing DI-registered `Logger` and log every previously-swallowed exception.
- All `catch (Throwable)` blocks are narrowed to `Exception`, and suspend paths rethrow `CancellationException` — copying the existing correct pattern from `VisitListViewModel.fetchOptimizedRoute`. `OsrmRoutingProvider` (which already logged) gets the `CancellationException` rethrow too.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## 🔗 Related Issues

Fixes #204

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally (full `testDebugUnitTest`)
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)