### PR TITLE
Use a dark vector basemap for MapLibre dark mode

### DIFF
--- a/app/src/main/assets/map/maplibre/visits-map.html
+++ b/app/src/main/assets/map/maplibre/visits-map.html
@@ -10,21 +10,25 @@
         #map { height: 100vh; width: 100%; }
         body { margin: 0; padding: 0; }
         .maplibregl-popup-content { padding: 8px 12px; }
-        @media (prefers-color-scheme: dark) {
-            #map { filter: brightness(0.7); }
-        }
     </style>
 </head>
 <body>
 <div id="map"></div>
 <script src="maplibre-gl.js"></script>
 <script>
+    // Vector map styles. Dark mode uses a genuinely dark-styled basemap
+    // (proper dark land/water/roads with readable labels) rather than a
+    // brightness/inversion filter over the light style.
+    const STYLE_LIGHT = 'https://tiles.openfreemap.org/styles/liberty';
+    const STYLE_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+
     let map;
     let markers = [];
     let routeAdded = false;
     let pendingSetMarkers = null;
     let labels = { currentLocation: undefined };
     let didFitBounds = false;
+    let isDarkMode = false;
 
     function log(message) {
         console.log(message);
@@ -38,7 +42,7 @@
 
     log('Script loaded successfully');
 
-    async function initializeMap(currentLocationText) {
+    async function initializeMap(currentLocationText, darkMode) {
         try {
             log('Initializing map');
 
@@ -47,10 +51,11 @@
             }
 
             labels.currentLocation = currentLocationText;
+            isDarkMode = !!darkMode;
 
             map = new maplibregl.Map({
                 container: 'map',
-                style: 'https://tiles.openfreemap.org/styles/liberty',
+                style: isDarkMode ? STYLE_DARK : STYLE_LIGHT,
                 center: [0, 0],
                 zoom: 2
             });
@@ -65,7 +70,7 @@
                     type: 'line',
                     source: 'route',
                     paint: {
-                        'line-color': '#2E86AB',
+                        'line-color': isDarkMode ? '#4DA6FF' : '#2E86AB',
                         'line-width': 4,
                         'line-opacity': 0.8
                     },

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitsMap.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitsMap.kt
@@ -1,5 +1,6 @@
 package com.msmobile.visitas.visit
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +18,7 @@ fun VisitsMap(
     onMapReady: () -> Unit = {}
 ) {
     val currentLocationText = stringResource(R.string.current_location).replace("'", "\\'")
+    val isDarkTheme = isSystemInDarkTheme()
     val webViewBridgeState = remember(engine) { mutableStateOf<WebViewViewBridge?>(null) }
 
     val (currentLatitude, currentLongitude) = currentLocation
@@ -40,7 +42,7 @@ fun VisitsMap(
         isFileAccessAllowed = true,
         onInitializationComplete = { webViewBridge ->
             webViewBridgeState.value = webViewBridge
-            val initScript = "initializeMap('${currentLocationText}');"
+            val initScript = "initializeMap('${currentLocationText}', $isDarkTheme);"
             webViewBridge.executeScript(initScript) { _ ->
                 val visitsJson = visitMapState.serialized
                 webViewBridge.executeScript("setMarkers($currentLatitude, $currentLongitude, $visitsJson);") { }


### PR DESCRIPTION
## 📝 Description
- Gives the MapLibre map a real dark mode. Previously dark mode applied `filter: brightness(0.7)` over the light basemap, which just dimmed everything (muddy labels, washed-out water). Now the WebView loads a genuinely dark-styled **vector** basemap (CARTO dark-matter) — proper dark land/water/roads with readable labels, no inversion or filtering.
- The theme is read from the Kotlin side via `isSystemInDarkTheme()` and passed into `initializeMap(currentLocationText, darkMode)`, matching how the rest of the app derives its theme.
- The route polyline brightens (`#4DA6FF`) on the dark basemap for contrast.

Scope is MapLibre only: the Leaflet engine renders raster OSM tiles, for which no equivalent dark vector style exists. Leaflet's `initializeMap` harmlessly ignores the extra argument.

## 🐞 Type of Change

- [x] New feature

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions
