### PR TITLE
Parse lat/long coordinates from map URLs

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/util/LatLongParser.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/LatLongParser.kt
@@ -8,17 +8,49 @@ data class LatLong(
 )
 
 class LatLongParser @Inject constructor() {
-    private val latLongPattern = Regex(
+    // Matches a plain "lat,long" or "lat long" string in its entirety.
+    private val plainPattern = Regex(
         """^\s*(-?\d+(?:\.\d+)?)\s*[,\s]\s*(-?\d+(?:\.\d+)?)\s*$"""
     )
 
-    fun parse(input: String): Result<LatLong> {
-        val match = latLongPattern.matchEntire(input)
-            ?: return Result.failure(IllegalArgumentException("Invalid lat,long format"))
+    // Ordered list of patterns used to extract a coordinate pair from within a
+    // larger string such as a map URL. Each pattern captures latitude in group 1
+    // and longitude in group 2. Patterns require decimal coordinates so unrelated
+    // URL segments (e.g. "!3m4!1e1" in Google Maps links) are not matched.
+    private val urlPatterns = listOf(
+        // Query parameters: ?q=lat,long, &query=lat,long, ll=, destination=, etc.
+        Regex(
+            """[?&](?:q|query|ll|sll|saddr|daddr|destination|center)=""" +
+                """(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)"""
+        ),
+        // Map center / street view: @lat,long
+        Regex("""@(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)"""),
+        // Path segment: /place/lat,long or /lat,long
+        Regex("""/(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)"""),
+        // Generic fallback: first decimal coordinate pair anywhere in the string.
+        Regex("""(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)""")
+    )
 
-        val latitude = match.groupValues[1].toDoubleOrNull()
+    fun parse(input: String): Result<LatLong> {
+        plainPattern.matchEntire(input)?.let { match ->
+            return buildResult(match.groupValues[1], match.groupValues[2])
+        }
+
+        for (pattern in urlPatterns) {
+            val match = pattern.find(input) ?: continue
+            val result = buildResult(match.groupValues[1], match.groupValues[2])
+            if (result.isSuccess) {
+                return result
+            }
+        }
+
+        return Result.failure(IllegalArgumentException("Invalid lat,long format"))
+    }
+
+    private fun buildResult(latText: String, longText: String): Result<LatLong> {
+        val latitude = latText.toDoubleOrNull()
             ?: return Result.failure(IllegalArgumentException("Invalid latitude"))
-        val longitude = match.groupValues[2].toDoubleOrNull()
+        val longitude = longText.toDoubleOrNull()
             ?: return Result.failure(IllegalArgumentException("Invalid longitude"))
 
         if (latitude !in -90.0..90.0) {
@@ -31,4 +63,3 @@ class LatLongParser @Inject constructor() {
         return Result.success(LatLong(latitude, longitude))
     }
 }
-

--- a/app/src/test/java/com/msmobile/visitas/util/LatLongParserTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/util/LatLongParserTest.kt
@@ -1,0 +1,97 @@
+package com.msmobile.visitas.util
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class LatLongParserTest {
+
+    private val parser = LatLongParser()
+
+    @Test
+    fun `parses plain comma separated coordinates`() {
+        val result = parser.parse("-28.6497173,-49.4233284")
+
+        assertEquals(LatLong(-28.6497173, -49.4233284), result.getOrNull())
+    }
+
+    @Test
+    fun `parses plain space separated coordinates`() {
+        val result = parser.parse("40.7128 -74.0060")
+
+        assertEquals(LatLong(40.7128, -74.0060), result.getOrNull())
+    }
+
+    @Test
+    fun `parses coordinates with surrounding whitespace`() {
+        val result = parser.parse("  12.34 , 56.78  ")
+
+        assertEquals(LatLong(12.34, 56.78), result.getOrNull())
+    }
+
+    @Test
+    fun `parses integer coordinates`() {
+        val result = parser.parse("10,20")
+
+        assertEquals(LatLong(10.0, 20.0), result.getOrNull())
+    }
+
+    @Test
+    fun `parses coordinates from google maps at url`() {
+        val url = "https://www.google.com/maps/@-28.6497173,-49.4233284,3a,88.1y," +
+            "335.32h,79.47t/data=!3m4!1e1!3m2!1sub2dc7cB7URMJwA7UqDgaA!2e0" +
+            "?utm_campaign=ml-ardl&g_ep=Eg1tbF8yMDI2MDYxMF8wIJvbDyoASAJQAQ%3D%3D"
+
+        val result = parser.parse(url)
+
+        assertEquals(LatLong(-28.6497173, -49.4233284), result.getOrNull())
+    }
+
+    @Test
+    fun `parses coordinates from google maps query url`() {
+        val url = "https://www.google.com/maps?q=-23.5505199,-46.6333094"
+
+        val result = parser.parse(url)
+
+        assertEquals(LatLong(-23.5505199, -46.6333094), result.getOrNull())
+    }
+
+    @Test
+    fun `parses coordinates from place path url`() {
+        val url = "https://www.google.com/maps/place/40.785091,-73.968285"
+
+        val result = parser.parse(url)
+
+        assertEquals(LatLong(40.785091, -73.968285), result.getOrNull())
+    }
+
+    @Test
+    fun `fails when latitude is out of range`() {
+        val result = parser.parse("100.0,20.0")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `fails when longitude is out of range`() {
+        val result = parser.parse("20.0,200.0")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `fails when no coordinates are present`() {
+        val result = parser.parse("https://www.google.com/maps/search/coffee")
+
+        assertTrue(result.isFailure)
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun `fails for arbitrary text`() {
+        val result = parser.parse("Rua das Flores 123")
+
+        assertTrue(result.isFailure)
+    }
+}


### PR DESCRIPTION
## 📝 Description

`LatLongParser` agora consegue extrair coordenadas de latitude/longitude não só de strings simples (`"lat,long"` ou `"lat long"`), mas também de **dentro de URLs de mapas** — como links do Google Maps.

Antes, o parser usava `matchEntire`, exigindo que a string inteira fosse apenas as coordenadas. Colar uma URL como:

```
https://www.google.com/maps/@-28.6497173,-49.4233284,3a,88.1y,335.32h,79.47t/data=!3m4!1e1!3m2!1sub2dc7cB7URMJwA7UqDgaA!2e0?utm_campaign=ml-ardl&g_ep=...
```

falhava. Agora ela é reconhecida e extrai `-28.6497173, -49.4233284`.

**Como funciona:** o comportamento exato anterior é preservado (match da string inteira para `lat,long`/`lat long`, inclusive inteiros). Quando isso não casa, um conjunto ordenado de padrões tenta extrair coordenadas de formatos comuns de URL:

1. Parâmetros de query: `?q=`, `&query=`, `ll=`, `sll=`, `saddr=`, `daddr=`, `destination=`, `center=`
2. Marcador de centro do mapa / street view: `@lat,long`
3. Segmento de caminho: `/place/lat,long` ou `/lat,long`
4. Fallback genérico: primeiro par de coordenadas decimais na string

Os padrões de URL exigem coordenadas **decimais**, evitando casar com segmentos não relacionados dos links do Google Maps (ex.: `!3m4!1e1!3m2`). A validação de faixa (`-90..90` / `-180..180`) continua aplicada.

## 🐞 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

> ℹ️ Adicionado `LatLongParserTest` cobrindo entradas simples e extração de URLs (incl. o exemplo `@lat,long`, `?q=lat,long` e `/place/lat,long`). Não foi possível executar os testes neste ambiente sandbox (download do Gradle 9.5.1 / toolchain JDK bloqueado pela rede), então deixo a validação de "compila" e "testes passam" a cargo do CI.

https://claude.ai/code/session_01D9xFUsPCWWAzBNcDm4v6Zs