### PR TITLE
Add Regenerate Screenshots workflow

### DIFF
--- a/.github/workflows/regenerate-screenshots.yml
+++ b/.github/workflows/regenerate-screenshots.yml
@@ -1,0 +1,79 @@
+name: Regenerate Screenshots
+
+# Manually-dispatchable job that regenerates Compose screenshot reference
+# images for a given branch and commits them back. Useful when the
+# validateDebugScreenshotTest check fails because UI changes need new baselines.
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to regenerate screenshot references on'
+        required: true
+        type: string
+
+concurrency:
+  group: regenerate-screenshots-${{ github.event.inputs.target_branch }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate Screenshots
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+          # PAT so the commit-back push re-triggers the PR Build check
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Create Google Services JSON
+        env:
+          GOOGLE_SERVICES_DEBUG: ${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}
+        run: |
+          mkdir -p app/src/debug
+          printf '%s' "$GOOGLE_SERVICES_DEBUG" > app/src/debug/google-services.json
+          if [ ! -f "app/src/debug/google-services.json" ]; then
+            echo "ERROR: google-services.json was not created"
+            exit 1
+          fi
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+            gradle-
+
+      - name: Regenerate screenshot references
+        run: ./gradlew updateDebugScreenshotTest
+        env:
+          ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Commit and push updated references
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app/src/screenshotTestDebug/reference
+          if git diff --cached --quiet; then
+            echo "No screenshot reference changes to commit."
+            exit 0
+          fi
+          git commit -m "Update screenshot references via regenerate-screenshots workflow"
+          git push origin HEAD:${{ github.event.inputs.target_branch }}


### PR DESCRIPTION
## 📝 Description

Adds a new manually-dispatchable GitHub Actions workflow, `.github/workflows/regenerate-screenshots.yml`, that regenerates the Compose screenshot reference images on a given branch and commits them back.

**What it does**
- Triggered via `workflow_dispatch` with a required `target_branch` input.
- Checks out the target branch, sets up Temurin JDK 17, recreates `app/src/debug/google-services.json` from the `GOOGLE_SERVICES_JSON_DEBUG` secret, and passes the `ENCRYPTION_PASSPHRASE` and `SENTRY_DSN` secrets to Gradle — mirroring the existing `pull-request-build.yml` setup.
- Runs `./gradlew updateDebugScreenshotTest` (the remote equivalent of what contributors run locally to refresh baselines), then commits and pushes the updated PNGs under `app/src/screenshotTestDebug/reference/`. If nothing changed, it exits cleanly without committing.

**Why `WORKFLOW_TOKEN`**
- The checkout/push uses the existing `WORKFLOW_TOKEN` PAT (same one used by `branch-sync.yml`, `backmerge.yml`, and `cut-release.yml`) instead of the default `GITHUB_TOKEN`. The default token does NOT re-trigger workflow runs on push, so reusing the PAT ensures the commit-back push re-triggers the PR Build check (`validateDebugScreenshotTest`) automatically.

**How to use once merged**
- Dispatch the workflow with the `target_branch` input set to the branch that needs new baselines, e.g. `claude/issue-14-review-npjvmw`, to regenerate screenshots remotely and have the refreshed references pushed back to that branch.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

https://claude.ai/code/session_01K6TfVdvNDP9zuQ8x7YZ7zQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6TfVdvNDP9zuQ8x7YZ7zQ)_