### PR TITLE
Fix 8→9 Room migration crash (visit_householder view) — 1.4.1

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/migration/Migration_8_9.kt
+++ b/app/src/main/java/com/msmobile/visitas/migration/Migration_8_9.kt
@@ -8,5 +8,36 @@ val MIGRATION_8_9 = object : Migration(8, 9) {
         db.execSQL(
             "ALTER TABLE visit ADD COLUMN isDraft INTEGER NOT NULL DEFAULT 0"
         )
+
+        // The visit_householder view references the new isDraft column, so it must be
+        // recreated to match the @DatabaseView definition in VisitHouseholder.kt.
+        // Room compares view SQL character-by-character during schema validation, so
+        // this must stay in sync with that annotation (see Migration_4_5 for the same pattern).
+        db.execSQL("DROP VIEW IF EXISTS visit_householder")
+        db.execSQL(
+            """
+            |CREATE VIEW `visit_householder` AS SELECT
+            |        v.id as visitId,
+            |        v.subject as subject,
+            |        v.date as date,
+            |        v.isDone as isDone,
+            |        v.isDraft as isDraft,
+            |        v.householderId as householderId,
+            |        v.visitType as type,
+            |        h.name as householderName,
+            |        h.address as householderAddress,
+            |        h.addressLatitude as householderLatitude,
+            |        h.addressLongitude as householderLongitude
+            |    FROM visit v
+            |    JOIN householder h ON v.householderId = h.id
+            |    INNER JOIN (
+            |        SELECT householderId, MAX(date) as max_date
+            |        FROM visit
+            |        GROUP BY householderId
+            |    ) latest ON v.householderId = latest.householderId 
+            |        AND v.date = latest.max_date
+            |    ORDER BY v.householderId, v.date DESC
+            |    """.trimMargin()
+        )
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.4.0
+versionName=1.4.1


### PR DESCRIPTION
## Summary

Hotfix for crash reports (Sentry) on the **8 → 9 Room migration**:

```
java.lang.IllegalStateException: Migration didn't properly handle: visit_householder
```

### Root cause
`MIGRATION_8_9` adds the `isDraft` column to the `visit` table, but the `visit_householder` `@DatabaseView` (`VisitHouseholder.kt`) references `v.isDraft as isDraft`. The migration never recreated the view, so after upgrading the in-DB view still lacked the column. Room validates view SQL after migration and compares it character-for-character, so the mismatch (Expected has `v.isDraft`, Found doesn't) throws and crashes on app startup.

### Fix
In `MIGRATION_8_9`, after the `ALTER TABLE`, drop and recreate the `visit_householder` view including the `isDraft` column, matching the `@DatabaseView` annotation byte-for-byte (same pattern already used in `MIGRATION_4_5`, including the margin/trailing-space formatting Room is sensitive to).

Verified by structural diff: the new view SQL is identical to the proven `MIGRATION_4_5` view, differing only by the single added `v.isDraft as isDraft,` line.

### Version
Bumps `version.properties` to **1.4.1** (patch release).

## Testing notes
- ⚠️ Could not compile in CI sandbox — the Gradle distribution download is blocked (HTTP 403). Please run `./gradlew :app:compileDebugKotlin` and a Room migration test (8 → 9) before merging.

## Notes / caveats
- The deploy/release workflows validate that the branch name matches `versionName` (expected branch `release/<versionName>`). With `versionName=1.4.1`, that check expects a `release/1.4.1` branch. Confirm whether `release/1.4.0` should be retargeted/renamed to `release/1.4.1` as part of this patch, or adjust the release flow accordingly.

https://claude.ai/code/session_01W4N4VrnyD11qzbW8ghKLxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4N4VrnyD11qzbW8ghKLxT)_