### PR TITLE
Set version.properties from input when cutting a release branch

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -51,17 +51,25 @@ jobs:
           fi
           echo "Branch $BRANCH does not exist — safe to proceed"
 
-      - name: Create release branch via API
+      - name: Create release branch
         run: |
           BRANCH="${{ steps.version.outputs.branch }}"
-          SHA=$(git rev-parse HEAD)
-          gh api repos/${{ github.repository }}/git/refs \
-            -X POST \
-            -f ref="refs/heads/${BRANCH}" \
-            -f sha="${SHA}"
-          echo "Release branch ${BRANCH} created at ${SHA}."
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          NAME="${{ steps.version.outputs.name }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          # If a version was supplied, set it in version.properties before pushing.
+          # The creating push is allowed even though release/* is protected — only
+          # later updates to the branch require a PR.
+          if [ -n "${{ inputs.version_name }}" ]; then
+            sed -i "s/^versionName=.*/versionName=${NAME}/" version.properties
+            if ! git diff --quiet version.properties; then
+              git add version.properties
+              git commit -m "Set release version to ${NAME}"
+            fi
+          fi
+          git push origin "$BRANCH"
+          echo "Release branch ${BRANCH} created."
 
   open-version-bump-pr:
     name: Open Version Bump PR on Master


### PR DESCRIPTION
## 📝 Description
When cutting a release branch with a `version_name` input, `cut-release` now writes that version into `version.properties` and commits it before pushing the new branch. The branch is created via a plain `git push` (the creating push is allowed by the `release/*` ruleset; only subsequent updates require a PR), replacing the previous refs-API creation.

This keeps the release branch's `versionName` in sync with the branch name, so `release-build.yml`'s branch/version guard passes when the released version is overridden via input.

## 🐞 Type of Change

- [x] CI/CD

## ☑️ Checklist

- [ ] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions