### PR TITLE
Translate Draft label in es-419 and pt-rBR

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -26,6 +26,7 @@
     <string name="visits">Visitas</string>
     <string name="add_visit">Agregar visita</string>
     <string name="visit_is_done">Visita realizada</string>
+    <string name="visit_draft">Borrador</string>
     <string name="done_visits">Realizadas</string>
     <string name="remove_visit">Eliminar visita</string>
     <string name="previous_month">Mes anterior</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,6 +25,7 @@
     <string name="visits">Visitas</string>
     <string name="add_visit">Adicionar visita</string>
     <string name="visit_is_done">Visita feita</string>
+    <string name="visit_draft">Rascunho</string>
     <string name="done_visits">Feitas</string>
     <string name="remove_visit">Remove visit</string>
     <string name="previous_month">Mês anterior</string>


### PR DESCRIPTION
## 📝 Description
- The `visit_draft` string ("Draft") was only defined in the default locale, so the label displayed in English for Spanish and Portuguese users.
- Adds the missing translation: **Borrador** (es-419) and **Rascunho** (pt-rBR).

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions