### PR TITLE
Prevent backmerge from downgrading version.properties

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -68,6 +68,15 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
             echo "Merge conflicts with master — pushing unmerged head; resolve on $BACKMERGE_BRANCH"
           fi
+          # version.properties holds master's next-dev version. A backmerge must
+          # never drag it down to the release version — always keep master's. Git
+          # otherwise silently takes the release value, since master is unchanged
+          # from the merge-base and so no conflict is raised.
+          git checkout origin/master -- version.properties
+          git add version.properties
+          if ! git diff --cached --quiet; then
+            git commit -m "Backmerge: keep master's version.properties"
+          fi
           git push -f origin "$BACKMERGE_BRANCH"
 
       - name: Open or refresh PR to master


### PR DESCRIPTION
## 📝 Description
The backmerge workflow downgrades master's `version.properties` on every release backmerge (e.g. PR #239 set master from `1.5.0` back to `1.4.2`).

The backmerge branch is cut from the release branch, where `version.properties` is pinned to the release version, while master holds the next-dev version. Because master is **unchanged from the merge-base**, Git silently keeps the release side on merge — no conflict is raised — so the resulting PR carries a version downgrade into master.

This pins `version.properties` to master's copy after the merge, so it is never carried back from a release branch. Applies on both the clean-merge and conflict paths (in the conflict path the pin commits onto the branch before a human resolves the remaining conflicts, so the version doesn't silently downgrade unnoticed).

> Note: `.gitattributes merge=ours` cannot fix this — a merge driver only fires when both sides change the file, and here master never does.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)