### PR TITLE
Backmerge release/1.4.2 into master

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -68,6 +68,15 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
             echo "Merge conflicts with master — pushing unmerged head; resolve on $BACKMERGE_BRANCH"
           fi
+          # version.properties holds master's next-dev version. A backmerge must
+          # never drag it down to the release version — always keep master's. Git
+          # otherwise silently takes the release value, since master is unchanged
+          # from the merge-base and so no conflict is raised.
+          git checkout origin/master -- version.properties
+          git add version.properties
+          if ! git diff --cached --quiet; then
+            git commit -m "Backmerge: keep master's version.properties"
+          fi
           git push -f origin "$BACKMERGE_BRANCH"
 
       - name: Open or refresh PR to master

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -26,6 +26,7 @@
     <string name="visits">Visitas</string>
     <string name="add_visit">Agregar visita</string>
     <string name="visit_is_done">Visita realizada</string>
+    <string name="visit_draft">Borrador</string>
     <string name="done_visits">Realizadas</string>
     <string name="remove_visit">Eliminar visita</string>
     <string name="previous_month">Mes anterior</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,6 +25,7 @@
     <string name="visits">Visitas</string>
     <string name="add_visit">Adicionar visita</string>
     <string name="visit_is_done">Visita feita</string>
+    <string name="visit_draft">Rascunho</string>
     <string name="done_visits">Feitas</string>
     <string name="remove_visit">Remove visit</string>
     <string name="previous_month">Mês anterior</string>

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.5.0
+versionName=1.4.2

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.4.2
+versionName=1.5.0


### PR DESCRIPTION
Automated backmerge of `release/1.4.2` into master. Master was merged into this branch cleanly — no conflicts.

> Merge with a **merge commit** (not squash) to preserve ancestry.