### PR TITLE
Remove the confirmation requirement when discarding changes

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -880,7 +880,7 @@ private fun StateHandler(
     onEvent: (VisitDetailViewModel.UiEvent) -> Unit
 ) {
     when (val eventState = uiState.eventState) {
-        is VisitDetailViewModel.UiEventState.Canceled,
+        is VisitDetailViewModel.UiEventState.Dismissed,
         is VisitDetailViewModel.UiEventState.SaveSucceeded,
         is VisitDetailViewModel.UiEventState.Deleted -> {
             LaunchedEffect(eventState) {

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailScreen.kt
@@ -950,10 +950,6 @@ private fun StateHandler(
             DeleteMessage(onEvent)
         }
 
-        is VisitDetailViewModel.UiEventState.DiscardChangesConfirmation -> {
-            DiscardChangesMessage(onEvent)
-        }
-
         is VisitDetailViewModel.UiEventState.NoAddressFound -> {
             NoAddressFoundSnackbar(
                 modifier = Modifier.snackbarPadding(),
@@ -999,39 +995,6 @@ private fun DeleteMessage(onEvent: (VisitDetailViewModel.UiEvent) -> Unit) {
             TextButton(
                 onClick = {
                     onEvent(VisitDetailViewModel.UiEvent.DeleteDismissed)
-                }
-            ) {
-                Text(stringResource(id = R.string.cancel))
-            }
-        }
-    )
-}
-
-@Composable
-private fun DiscardChangesMessage(onEvent: (VisitDetailViewModel.UiEvent) -> Unit) {
-    AlertDialog(
-        onDismissRequest = {
-            onEvent(VisitDetailViewModel.UiEvent.DiscardChangesDismissed)
-        },
-        title = {
-            Text(text = stringResource(id = R.string.discard_changes_title))
-        },
-        text = {
-            Text(text = stringResource(id = R.string.should_discard_changes))
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onEvent(VisitDetailViewModel.UiEvent.DiscardChangesAccepted)
-                }
-            ) {
-                Text(stringResource(id = R.string.confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = {
-                    onEvent(VisitDetailViewModel.UiEvent.DiscardChangesDismissed)
                 }
             ) {
                 Text(stringResource(id = R.string.cancel))

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -158,7 +158,7 @@ class VisitDetailViewModel
     }
 
     private fun discardChangesAccepted() {
-        discardChanges()
+        dismiss()
     }
 
     private fun snackbarDismissed() {
@@ -661,21 +661,13 @@ class VisitDetailViewModel
     }
 
     private fun cancelClicked() {
-        if (didEditableDataChange) {
-            newState {
-                copy(
-                    eventState = UiEventState.DiscardChangesConfirmation
-                )
-            }
-        } else {
-            discardChanges()
-        }
+        dismiss()
     }
 
-    private fun discardChanges() {
+    private fun dismiss() {
         newState {
             copy(
-                eventState = UiEventState.Canceled
+                eventState = UiEventState.Dismissed
             )
         }
     }
@@ -1458,7 +1450,7 @@ class VisitDetailViewModel
     sealed class UiEventState {
         data object Idle : UiEventState()
         data object NoAddressFound : UiEventState()
-        data object Canceled : UiEventState()
+        data object Dismissed : UiEventState()
         data object Saving : UiEventState()
         data object SaveSucceeded : UiEventState()
         data object ValidationError : UiEventState()

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -123,8 +123,6 @@ class VisitDetailViewModel
             is UiEvent.PreferredDayChanged -> preferredDayChanged(uiEvent.value)
             is UiEvent.PreferredTimeChanged -> preferredTimeChanged(uiEvent.value)
 
-            UiEvent.DiscardChangesAccepted -> discardChangesAccepted()
-            UiEvent.DiscardChangesDismissed -> discardChangesDismissed()
             UiEvent.LoadAddressClicked -> loadAddressClicked()
             UiEvent.LookUpAddressFromLatLongClicked -> lookUpAddressFromLatLongClicked()
             UiEvent.CancelClicked -> cancelClicked()
@@ -149,16 +147,6 @@ class VisitDetailViewModel
             UiEvent.CalendarPermissionDialogShown -> handleCalendarPermissionDialogShown()
             UiEvent.CopyVisitDataClicked -> copyVisitDataClicked()
         }
-    }
-
-    private fun discardChangesDismissed() {
-        newState {
-            copy(eventState = UiEventState.Idle)
-        }
-    }
-
-    private fun discardChangesAccepted() {
-        dismiss()
     }
 
     private fun snackbarDismissed() {
@@ -1443,8 +1431,6 @@ class VisitDetailViewModel
         data object CalendarPermissionGranted : UiEvent()
         data object CalendarPermissionDialogShown : UiEvent()
         data object CopyVisitDataClicked : UiEvent()
-        data object DiscardChangesAccepted : UiEvent()
-        data object DiscardChangesDismissed : UiEvent()
     }
 
     sealed class UiEventState {
@@ -1458,7 +1444,6 @@ class VisitDetailViewModel
         data object DeleteConfirmation : UiEventState()
         data object Deleting : UiEventState()
         data object Deleted : UiEventState()
-        data object DiscardChangesConfirmation : UiEventState()
         data class NextVisitSuggestionShowing(val visit: VisitState) : UiEventState()
         data object CopiedToClipboard : UiEventState()
     }

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -14,8 +14,6 @@
     <string name="delete">Eliminar</string>
     <string name="confirm">Confirmar</string>
     <string name="would_you_like_to_delete_this">¿Está seguro de que desea eliminar este registro?</string>
-    <string name="discard_changes_title">Los cambios se perderán</string>
-    <string name="should_discard_changes">¿Desea continuar sin guardar los cambios?</string>
     <string name="delete_title">Eliminar registro</string>
     <string name="first_visit">Primera visita</string>
     <string name="add_conversation">Agregar conversación</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -13,8 +13,6 @@
     <string name="delete">Excluir</string>
     <string name="confirm">Confirmar</string>
     <string name="would_you_like_to_delete_this">Tem certeza que deseja excluir esse registro?</string>
-    <string name="discard_changes_title">Alterações serão perdidas</string>
-    <string name="should_discard_changes">Deseja continuar sem salvar as alterações?</string>
     <string name="delete_title">Excluir registro</string>
     <string name="first_visit">Primeira visita</string>
     <string name="add_conversation">Adicionar conversa</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,6 @@
     <string name="delete">Delete</string>
     <string name="confirm">Confirm</string>
     <string name="would_you_like_to_delete_this">Are you sure you want to delete this record?</string>
-    <string name="discard_changes_title">Changes will be lost</string>
-    <string name="should_discard_changes">Do you want to continue without saving changes?</string>
     <string name="delete_title">Delete record</string>
     <string name="first_visit">First visit</string>
     <string name="add_conversation">Add conversation</string>

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -388,7 +388,7 @@ class VisitDetailViewModelTest {
 
         // Assert
         assertEquals(
-            VisitDetailViewModel.UiEventState.Canceled,
+            VisitDetailViewModel.UiEventState.Dismissed,
             viewModel.uiState.value.eventState
         )
     }
@@ -425,7 +425,7 @@ class VisitDetailViewModelTest {
 
         // Assert
         assertEquals(
-            VisitDetailViewModel.UiEventState.Canceled,
+            VisitDetailViewModel.UiEventState.Dismissed,
             viewModel.uiState.value.eventState
         )
     }

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -394,34 +394,14 @@ class VisitDetailViewModelTest {
     }
 
     @Test
-    fun `onEvent with DiscardChangesDismissed returns to Idle state`() {
-        // Arrange
-        val viewModel = createViewModel()
-        // Make an edit to trigger discard confirmation
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = null))
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.HouseholderNameChanged("New Name"))
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.CancelClicked)
-
-        // Act
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.DiscardChangesDismissed)
-
-        // Assert
-        assertEquals(
-            VisitDetailViewModel.UiEventState.Idle,
-            viewModel.uiState.value.eventState
-        )
-    }
-
-    @Test
-    fun `onEvent with DiscardChangesAccepted cancels and discards changes`() {
+    fun `onEvent with CancelClicked discards changes when edits made`() {
         // Arrange
         val viewModel = createViewModel()
         viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = null))
         viewModel.onEvent(VisitDetailViewModel.UiEvent.HouseholderNameChanged("New Name"))
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.CancelClicked)
 
         // Act
-        viewModel.onEvent(VisitDetailViewModel.UiEvent.DiscardChangesAccepted)
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.CancelClicked)
 
         // Assert
         assertEquals(


### PR DESCRIPTION
## 📝 Description
- Removes the "Discard changes?" confirmation dialog when leaving the visit detail screen with unsaved edits. Tapping cancel/back now dismisses immediately.
- Renames the `Canceled` UI event state to `Dismissed` and collapses `discardChanges()`/`cancelClicked()` into a single `dismiss()` path, removing the `didEditableDataChange` branch and the `DiscardChangesConfirmation` state usage.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions