### PR TITLE
Always show draft visits in the visit list

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -663,7 +663,9 @@ constructor(
                 isFilteringByDistance = isFilteringByDistance,
                 householderDistanceAsFilter = householderDistanceAsFilter
             )
-            val show = isSearchEmpty && (matchesDate || matchesDistance)
+            val isDraft = visit.isDraft
+            val show = isDraft
+                    || isSearchEmpty && (matchesDate || matchesDistance)
                     || matchesName
             visit.copy(hide = !show) to matchesDistance
         }.sortedWith(

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
@@ -342,6 +342,48 @@ class VisitListViewModelTest {
     }
 
     @Test
+    fun `draft visit stays visible even when search filter does not match its name`() {
+        // Arrange: a draft visit whose name does not match the search query
+        val draftVisit = VisitHouseholder(
+            visitId = FIRST_VISIT_ID,
+            subject = "Draft subject",
+            date = LocalDateTime.now(),
+            isDone = false,
+            isDraft = true,
+            householderId = FIRST_HOUSEHOLDER_ID,
+            householderName = "Draft Householder",
+            householderAddress = "Address 1",
+            type = VisitType.FIRST_VISIT,
+            householderLatitude = null,
+            householderLongitude = null
+        )
+        val matchingVisit = VisitHouseholder(
+            visitId = SECOND_VISIT_ID,
+            subject = "Subject 2",
+            date = LocalDateTime.now(),
+            isDone = false,
+            householderId = SECOND_HOUSEHOLDER_ID,
+            householderName = "Searchable Name",
+            householderAddress = "Address 2",
+            type = VisitType.RETURN_VISIT,
+            householderLatitude = null,
+            householderLongitude = null
+        )
+        val viewModel = createViewModel(visits = listOf(draftVisit, matchingVisit))
+        viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+
+        // Act: search for a term that only matches the non-draft visit
+        viewModel.onEvent(VisitListViewModel.UiEvent.SearchChanged("Searchable"))
+
+        // Assert: the draft remains visible despite not matching the search
+        val draft = viewModel.uiState.value.visitList.find { it.visitId == FIRST_VISIT_ID }
+        assertFalse(
+            "Draft visit should stay visible even when it does not match the search filter",
+            draft?.hide ?: true
+        )
+    }
+
+    @Test
     fun `onEvent with ViewCreated loads visitMapEngine from preference`() {
         val viewModel = createViewModel(savedMapEngine = VisitMapEngineOption.Leaflet)
 
@@ -357,7 +399,8 @@ class VisitListViewModelTest {
         locationFlowRef: MockReferenceHolder<MutableStateFlow<UserLocationProvider.UserLocation>>? = null,
         distanceResults: Map<DistanceInput, AddressProvider.AddressDistance> = emptyMap(),
         visitListDateFilterOption: VisitListDateFilterOption = VisitListDateFilterOption.All,
-        savedMapEngine: VisitMapEngineOption = VisitMapEngineOption.MapLibre
+        savedMapEngine: VisitMapEngineOption = VisitMapEngineOption.MapLibre,
+        visits: List<VisitHouseholder> = createVisitHouseholderList()
     ): VisitListViewModel {
         val dispatchers = DispatcherProvider(
             io = mainDispatcherRule.dispatcher
@@ -374,7 +417,7 @@ class VisitListViewModelTest {
             on { hasPermissions(any(), any()) } doReturn hasLocationPermission
         }
         val visitHouseholderRepository = mock<VisitHouseholderRepository> {
-            on { getAll() } doReturn createVisitHouseholderList()
+            on { getAll() } doReturn visits
         }
         visitHouseholderRepositoryRef?.value = visitHouseholderRepository
 


### PR DESCRIPTION
## 📝 Description
- Draft visits are now always shown in the visit list, regardless of the active search, date, or distance filters. This matches the existing behavior of pinning drafts to the top of the list so an in-progress draft is never accidentally hidden by a filter.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions