### PR TITLE
Keep master's version.properties inside the backmerge merge commit

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -58,6 +58,18 @@ jobs:
           git checkout -B "$BACKMERGE_BRANCH"
           if git merge origin/master --no-edit; then
             echo "conflicts=false" >> $GITHUB_OUTPUT
+            # version.properties holds master's next-dev version. A backmerge must
+            # never drag it down to the release version — always keep master's. Git
+            # otherwise silently takes the release value, since master is unchanged
+            # from the merge-base and so no conflict is raised. Fold the fix INTO the
+            # merge commit (--amend) rather than a standalone commit: release notes are
+            # built with `git log --no-merges`, which would surface a standalone commit
+            # on every future release but excludes the merge commit itself.
+            git checkout origin/master -- version.properties
+            git add version.properties
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
+            fi
             echo "Merged master cleanly — PR will be immediately mergeable"
           else
             FILES=$(git diff --name-only --diff-filter=U)
@@ -66,16 +78,10 @@ jobs:
             echo "files<<EOF" >> $GITHUB_OUTPUT
             echo "$FILES" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+            # Don't add a standalone version.properties commit here — it would be a
+            # non-merge commit and leak into release notes. The resolver keeps master's
+            # version.properties inside their merge commit (see the conflict PR body).
             echo "Merge conflicts with master — pushing unmerged head; resolve on $BACKMERGE_BRANCH"
-          fi
-          # version.properties holds master's next-dev version. A backmerge must
-          # never drag it down to the release version — always keep master's. Git
-          # otherwise silently takes the release value, since master is unchanged
-          # from the merge-base and so no conflict is raised.
-          git checkout origin/master -- version.properties
-          git add version.properties
-          if ! git diff --cached --quiet; then
-            git commit -m "Backmerge: keep master's version.properties"
           fi
           git push -f origin "$BACKMERGE_BRANCH"
 
@@ -95,7 +101,7 @@ jobs:
           fi
           if [ "$HAS_CONFLICTS" = "true" ]; then
             TITLE="⚠️ Backmerge ${RELEASE_BRANCH} into master (conflicts)"
-            BODY=$(printf 'Automated backmerge of `%s` into master.\n\n**This branch conflicts with master.** Resolve on `%s` (never on the release branch):\n\n```\ngit fetch origin\ngit checkout %s\ngit merge origin/master   # resolve conflicts, commit\ngit push origin %s\n```\n\nConflicting files:\n```\n%s\n```\n\n> Merge with a **merge commit** (not squash) to preserve ancestry.' "$RELEASE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$CONFLICT_FILES")
+            BODY=$(printf 'Automated backmerge of `%s` into master.\n\n**This branch conflicts with master.** Resolve on `%s` (never on the release branch):\n\n```\ngit fetch origin\ngit checkout %s\ngit merge origin/master                          # resolve conflicts\ngit checkout origin/master -- version.properties # keep master'"'"'s next-dev version\ngit commit                                       # finalize the merge commit\ngit push origin %s\n```\n\nKeep master'"'"'s `version.properties` **inside the merge commit** (the `git checkout` step above) — a separate commit for it would leak into future release notes.\n\nConflicting files:\n```\n%s\n```\n\n> Merge with a **merge commit** (not squash) to preserve ancestry.' "$RELEASE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$BACKMERGE_BRANCH" "$CONFLICT_FILES")
             gh pr create --title "$TITLE" --body "$BODY" --base master --head "$BACKMERGE_BRANCH"
           else
             TITLE="Backmerge ${RELEASE_BRANCH} into master"

--- a/docs/superpowers/specs/2026-06-17-backmerge-version-properties-merge-commit-design.md
+++ b/docs/superpowers/specs/2026-06-17-backmerge-version-properties-merge-commit-design.md
@@ -1,0 +1,95 @@
+# Backmerge: fold version.properties fix into the merge commit
+
+**Date:** 2026-06-17
+**Status:** Approved
+**Scope:** `.github/workflows/backmerge.yml`
+
+## Problem
+
+`backmerge.yml` protects master's `version.properties` from being downgraded by a
+backmerge. It does this with a **standalone** commit:
+
+```sh
+git checkout origin/master -- version.properties
+git add version.properties
+if ! git diff --cached --quiet; then
+  git commit -m "Backmerge: keep master's version.properties"
+fi
+```
+
+That commit lands on the backmerge branch and — because backmerge PRs are merged
+with a merge commit (no squash) — is preserved verbatim on master's history. Release
+notes are generated with `git log <prev-tag>..<sha> --no-merges` (release-build.yml).
+The standalone commit is a **non-merge** commit, so it survives the `--no-merges`
+filter and appears in the release notes of every future release cut from master.
+
+## Why the downgrade happens at all (context)
+
+- **Default cut** (no `version_name`): the release branch never touches
+  `version.properties`; master is bumped via the bump PR. At backmerge, master is the
+  side that changed, so the merge correctly keeps master's value. No fix needed.
+- **Patch / `version_name` cut**: `cut-release` writes a `Set release version to X`
+  commit on the release branch. Now the release side diverged downward while master is
+  unchanged from the merge-base, so git silently adopts the release (lower) value with
+  no conflict. This is the case the fix exists for.
+
+The existing post-merge detection (`git diff --cached --quiet`) is already correct
+about **when** to apply the fix. The only problem is **how** it records it.
+
+## Design (Approach A)
+
+Keep the existing detection. Change the recording: fold the `version.properties`
+restoration **into the merge commit** instead of a standalone commit. `--no-merges`
+excludes merge commits, so nothing reaches the changelog.
+
+### No-conflict path
+
+After `git merge origin/master --no-edit` succeeds (a merge commit now exists):
+
+```sh
+git checkout origin/master -- version.properties
+git add version.properties
+if ! git diff --cached --quiet; then
+  git commit --amend --no-edit      # fold into the merge commit; parents preserved
+fi
+```
+
+`git commit --amend` preserves the merge commit's two parents, so it stays a merge
+commit (still `--no-merges`-excluded) and keeps its merge message. The existing
+`git push -f` publishes the rewritten commit.
+
+### Conflict path
+
+The merge is aborted and a human finishes it on the backmerge branch, producing their
+own merge commit. We must **not** add a standalone commit here (it would pollute the
+same way). Instead, the conflict-PR body instructs the resolver to restore master's
+`version.properties` as part of their merge commit:
+
+```
+git fetch origin
+git checkout <backmerge-branch>
+git merge origin/master                          # resolve conflicts
+git checkout origin/master -- version.properties # keep master's version
+git commit                                       # finalize the merge commit
+git push origin <backmerge-branch>
+```
+
+Because the fix lands inside the human's merge commit, it is also `--no-merges`-excluded.
+
+## Non-goals / rejected alternatives
+
+- **Approach B — drop the release's `version.properties` commit before merging.**
+  Path-independent, but the target commit is usually buried under hotfix commits at
+  backmerge time (a `rebase --onto` that can conflict) and must no-op safely in the
+  default-cut case to avoid rewriting history shared with master. More fragile than A
+  for no benefit, since A reuses the already-correct detection.
+
+## Verification
+
+- No-conflict, patch cut: backmerge branch's merge commit carries master's
+  `version.properties`; no `Backmerge: keep master's version.properties` commit exists;
+  `git log <range> --no-merges` does not list any version-keeping commit.
+- No-conflict, default cut: detection is a no-op (no diff), merge commit unchanged.
+- Conflict path: PR body shows the `git checkout origin/master -- version.properties`
+  step; no standalone commit is pushed by the workflow.
+- `grep -r "Backmerge: keep master's version.properties"` returns nothing.


### PR DESCRIPTION
## 📝 Description

The backmerge workflow protected master's `version.properties` from being downgraded by a release branch using a **standalone** commit (`Backmerge: keep master's version.properties`). Because backmerge PRs merge with a merge commit (no squash), that **non-merge** commit landed on master and leaked into the notes of every future release — release notes are generated with `git log … --no-merges`, which excludes merge commits but keeps standalone ones.

This folds the fix into the merge commit instead, so the same correct detection produces nothing the changelog can pick up.

- **No-conflict path:** keep the existing post-merge detection, but use `git commit --amend --no-edit` to fold the `version.properties` restoration into the merge commit (`--amend` preserves both merge parents, so it stays `--no-merges`-excluded).
- **Conflict path:** drop the standalone commit entirely (it would leak the same way) and add a `git checkout origin/master -- version.properties` step to the resolver instructions in the PR body, so the human keeps master's version *inside their merge commit*.

Design doc: `docs/superpowers/specs/2026-06-17-backmerge-version-properties-merge-commit-design.md`.

> Relies on backmerge PRs being **merged, not squashed** — squashing would flatten the merge commit and defeat `--no-merges`. That is already the workflow's convention.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors <!-- YAML validated with js-yaml; printf body rendered and verified -->
- [ ] Tests pass locally <!-- N/A — workflow only runs on push to release/** -->
- [ ] UI changes tested on device/emulator <!-- N/A -->
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)