### PR TITLE
Mark changed and added visits as draft on auto-save

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailPreviewConfigProvider.kt
@@ -13,7 +13,8 @@ private val previewDate1 = LocalDateTime.of(2024, 1, 15, 10, 12)
 private val previewDate2 = previewDate1.plusWeeks(1)
 
 @VisibleForTesting
-internal class VisitDetailPreviewConfigProvider : PreviewParameterProvider<VisitDetailPreviewConfig> {
+internal class VisitDetailPreviewConfigProvider :
+    PreviewParameterProvider<VisitDetailPreviewConfig> {
 
     override val values: Sequence<VisitDetailPreviewConfig> = sequenceOf(
         VisitDetailPreviewConfig(
@@ -219,7 +220,6 @@ private val previewNewVisitUiState = VisitDetailViewModel.VisitState(
         subject = "",
         date = previewDate1,
         isDone = false,
-        isDraft = true,
         orderIndex = 0,
         visitType = VisitDetailViewModel.VisitTypeState(
             type = VisitType.FIRST_VISIT,
@@ -237,7 +237,8 @@ private val previewNewVisitUiState = VisitDetailViewModel.VisitState(
     showNextVisitSuggestion = false,
     showClearSubject = false,
     wasRemoved = false,
-    caretPosition = 0
+    caretPosition = 0,
+    isDraft = true,
 )
 
 private val previewFirstVisitUiState = VisitDetailViewModel.VisitState(
@@ -246,7 +247,6 @@ private val previewFirstVisitUiState = VisitDetailViewModel.VisitState(
         subject = "What is God's Kingdom?",
         date = previewDate1,
         isDone = true,
-        isDraft = false,
         orderIndex = 0,
         visitType = VisitDetailViewModel.VisitTypeState(
             type = VisitType.FIRST_VISIT,
@@ -264,7 +264,8 @@ private val previewFirstVisitUiState = VisitDetailViewModel.VisitState(
     showNextVisitSuggestion = false,
     showClearSubject = false,
     wasRemoved = false,
-    caretPosition = 0
+    caretPosition = 0,
+    isDraft = false,
 )
 
 private val previewReturnVisit = VisitDetailViewModel.VisitState(
@@ -273,7 +274,6 @@ private val previewReturnVisit = VisitDetailViewModel.VisitState(
         subject = "Who is the King of God's Kingdom?",
         date = previewDate2,
         isDone = false,
-        isDraft = false,
         orderIndex = 0,
         visitType = VisitDetailViewModel.VisitTypeState(
             type = VisitType.RETURN_VISIT,
@@ -291,7 +291,8 @@ private val previewReturnVisit = VisitDetailViewModel.VisitState(
     showNextVisitSuggestion = false,
     showClearSubject = false,
     wasRemoved = false,
-    caretPosition = 0
+    caretPosition = 0,
+    isDraft = false,
 )
 
 private val previewConversationSuggestion = VisitDetailViewModel.ConversationState(

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -825,7 +825,7 @@ class VisitDetailViewModel
                 val baselineEditable = baseline.visits[visit.id]
                 val isNewOrChanged = baselineEditable == null || baselineEditable != visit.editable
                 if (isNewOrChanged && !visit.isDraft) {
-                    visit.copy(editable = visit.editable.copy(isDraft = true))
+                    visit.copy(isDraft = true)
                 } else {
                     visit
                 }
@@ -1028,7 +1028,6 @@ class VisitDetailViewModel
                 subject = "",
                 date = dateTimeProvider.nowLocalDateTime(),
                 isDone = false,
-                isDraft = true,
                 orderIndex = orderIndex,
                 visitType = VisitType.FIRST_VISIT.asState
             ),
@@ -1040,7 +1039,8 @@ class VisitDetailViewModel
             showNextVisitSuggestion = false,
             showClearSubject = false,
             wasRemoved = false,
-            caretPosition = 0
+            caretPosition = 0,
+            isDraft = true,
         )
     }
 
@@ -1141,7 +1141,6 @@ class VisitDetailViewModel
                 subject = subject,
                 date = date,
                 isDone = isDone,
-                isDraft = isDraft,
                 orderIndex = orderIndex,
                 visitType = visitType.asState
             ),
@@ -1154,7 +1153,8 @@ class VisitDetailViewModel
             showClearSubject = false,
             wasRemoved = false,
             caretPosition = subject.length,
-            calendarEventId = calendarEventId
+            calendarEventId = calendarEventId,
+            isDraft = isDraft,
         )
     }
 
@@ -1227,7 +1227,7 @@ class VisitDetailViewModel
             )
         }
 
-    private fun VisitState.finalized() = copy(editable = editable.copy(isDraft = false))
+    private fun VisitState.finalized() = copy(isDraft = false)
 
     private fun VisitState.asModel(householderId: UUID): Visit {
         return Visit(
@@ -1320,12 +1320,12 @@ class VisitDetailViewModel
         val wasRemoved: Boolean,
         val caretPosition: Int,
         val calendarEventId: Long? = null,
-        val hasVisitTimeError: Boolean = false
+        val hasVisitTimeError: Boolean = false,
+        val isDraft: Boolean,
     ) {
         val subject get() = editable.subject
         val date get() = editable.date
         val isDone get() = editable.isDone
-        val isDraft get() = editable.isDraft
         val orderIndex get() = editable.orderIndex
         val visitType get() = editable.visitType
     }
@@ -1386,7 +1386,6 @@ class VisitDetailViewModel
         val subject: String,
         val date: LocalDateTime,
         val isDone: Boolean,
-        val isDraft: Boolean,
         val orderIndex: Int,
         val visitType: VisitTypeState
     )

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitDetailViewModel.kt
@@ -794,14 +794,44 @@ class VisitDetailViewModel
         autoSaveJob = _uiState
             .debounce(250)
             .onEach { state ->
-                val snapshot = state.getEditableDataSnapshot()
-                if (initialEditableData != null && snapshot != initialEditableData) {
-                    saveDraftSilently(state)
-                    initialEditableData = snapshot
+                val baseline = initialEditableData ?: return@onEach
+
+                if (state.getEditableDataSnapshot() == baseline) {
+                    return@onEach
                 }
+
+                updateUiStateChangedVisitsAsDraft(baseline)
+
+                val updatedState = _uiState.value
+                saveDraftSilently(updatedState)
+                // Rebase from the marked state so the draft flags we just set
+                // don't count as a fresh change on the next emission.
+                initialEditableData = updatedState.getEditableDataSnapshot()
             }
             .flowOn(dispatchers.io)
             .launchIn(viewModelScope)
+    }
+
+    /**
+     * Marks every visit that was added or edited relative to [baseline] as a draft, so the UI
+     * can surface a "draft" indicator and the silent save persists the flag.
+     *
+     * A visit is considered a draft when it has no counterpart in the baseline (added) or when its
+     * editable data differs from the baseline counterpart (changed). Visits are matched by id.
+     */
+    private fun updateUiStateChangedVisitsAsDraft(baseline: EditableDataSnapshot) {
+        newState {
+            val updatedList = visitList.map { visit ->
+                val baselineEditable = baseline.visits[visit.id]
+                val isNewOrChanged = baselineEditable == null || baselineEditable != visit.editable
+                if (isNewOrChanged && !visit.isDraft) {
+                    visit.copy(editable = visit.editable.copy(isDraft = true))
+                } else {
+                    visit
+                }
+            }
+            copy(visitList = updatedList)
+        }
     }
 
     private suspend fun saveDraftSilently(state: UiState) {
@@ -1265,7 +1295,7 @@ class VisitDetailViewModel
     private fun UiState.getEditableDataSnapshot(): EditableDataSnapshot {
         return EditableDataSnapshot(
             householder = householder.editable,
-            visits = visitList.map { visit -> visit.editable }
+            visits = visitList.associate { visit -> visit.id to visit.editable }
         )
     }
 
@@ -1363,7 +1393,7 @@ class VisitDetailViewModel
 
     private data class EditableDataSnapshot(
         val householder: EditableHouseholderData,
-        val visits: List<EditableVisitData>
+        val visits: Map<UUID, EditableVisitData>
     )
 
     sealed class UiEvent {

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitDetailViewModelTest.kt
@@ -29,7 +29,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class VisitDetailViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
@@ -91,6 +93,37 @@ class VisitDetailViewModelTest {
         assertEquals("Test Name", state.householder.name)
         assertEquals("Test Address", state.householder.address)
         assertTrue(state.showDeleteButton)
+    }
+
+    @Test
+    fun `auto save marks an edited existing visit as draft`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        val visit = viewModel.uiState.value.visitList.first()
+        assertFalse(visit.isDraft)
+
+        // Act — edit the existing visit, then let the debounced auto-save run
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.VisitDoneChanged(value = true, visit = visit))
+        mainDispatcherRule.dispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        assertTrue(viewModel.uiState.value.visitList.first().isDraft)
+    }
+
+    @Test
+    fun `auto save does not mark an unchanged visit as draft when only householder changes`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.ViewCreated(householderId = HOUSEHOLDER_ID))
+        assertFalse(viewModel.uiState.value.visitList.first().isDraft)
+
+        // Act — change only the householder, then let the debounced auto-save run
+        viewModel.onEvent(VisitDetailViewModel.UiEvent.HouseholderNameChanged("Changed Name"))
+        mainDispatcherRule.dispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        assertFalse(viewModel.uiState.value.visitList.first().isDraft)
     }
 
     @Test


### PR DESCRIPTION
## 📝 Description
- Fixes auto-save so it identifies **which** visits changed or were added and marks them as `isDraft = true` in the UiState.
- Previously `startAutoSave` only did a whole-snapshot boolean check (`snapshot != initialEditableData`): it detected *that* something changed, saved silently, and advanced the baseline — but never flagged individual visits. As a result the "Draft" badge (`VisitDetailScreen`, `VisitListScreen`) only ever appeared for brand-new visits; edited existing visits were saved silently but never marked.
- The editable snapshot's visits were stored as a `List<EditableVisitData>` with no id, making per-visit matching impossible. They are now keyed by id (`Map<UUID, EditableVisitData>`), so each current visit can be diffed against its baseline counterpart.
- Auto-save now marks added (absent in baseline) and changed (editable differs) visits as draft, then rebases the baseline from the marked state so the flags it just set do not re-trigger a save loop.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
