### PR TITLE
Fix: reset isLoadingVisits state

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -342,6 +342,8 @@ constructor(
                     .calculateDistanceBetweenUserAndHouseholders(userLocation)
                     .applyFilters()
             }
+        }.invokeOnCompletion {
+            isLoadingVisits.set(false)
         }
     }
 


### PR DESCRIPTION
## 📝 Description
- Fixes a bug where `isLoadingVisits` was not being set back to `false` after the visits loading task completed.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions