### PR TITLE
Consolidate householder address fields into a sealed state

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListPreviewConfigProvider.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListPreviewConfigProvider.kt
@@ -129,7 +129,11 @@ private val previewVisitListUiState = VisitListViewModel.UiState(
         VisitListViewModel.VisitHouseholderState(
             householderId = UUID.randomUUID(),
             householderName = "Mary Magdalene",
-            householderAddress = "12 Olive Tree Street - Near the Garden of Gethsemane",
+            householderAddressState = VisitListViewModel.HouseholderAddressState.Data(
+                latitude = 0.0,
+                longitude = 0.0,
+                address = "12 Olive Tree Street - Near the Garden of Gethsemane"
+            ),
             householderAddressDistance = AddressProvider.AddressDistance.Nearby(100f),
             date = previewDate1,
             isDone = false,
@@ -140,14 +144,16 @@ private val previewVisitListUiState = VisitListViewModel.UiState(
             subjectPreview = "What is God's Kingdom? — Daniel 2:44",
             hide = false,
             visitId = UUID.randomUUID(),
-            type = VisitType.FIRST_VISIT,
-            householderLatitude = 0.0,
-            householderLongitude = 0.0
+            type = VisitType.FIRST_VISIT
         ),
         VisitListViewModel.VisitHouseholderState(
             householderId = UUID.randomUUID(),
             householderName = "Joseph of Arimathea",
-            householderAddress = "45 Cedar Avenue",
+            householderAddressState = VisitListViewModel.HouseholderAddressState.Data(
+                latitude = 0.0,
+                longitude = 0.0,
+                address = "45 Cedar Avenue"
+            ),
             date = previewDate2,
             isDone = false,
             hasDrafts = false,
@@ -157,15 +163,13 @@ private val previewVisitListUiState = VisitListViewModel.UiState(
             hide = false,
             visitId = UUID.randomUUID(),
             type = VisitType.FIRST_VISIT,
-            householderLatitude = 0.0,
-            householderLongitude = 0.0,
             householderAddressDistance = AddressProvider.AddressDistance.FarAway(600f),
             subject = "The resurrection of the dead"
         ),
         VisitListViewModel.VisitHouseholderState(
             householderId = UUID.randomUUID(),
             householderName = "Nicodemus",
-            householderAddress = "7 Pharisee Street",
+            householderAddressState = VisitListViewModel.HouseholderAddressState.NoData,
             date = previewDate3,
             isDone = false,
             hasDrafts = false,
@@ -175,8 +179,6 @@ private val previewVisitListUiState = VisitListViewModel.UiState(
             hide = false,
             visitId = UUID.randomUUID(),
             type = VisitType.FIRST_VISIT,
-            householderLatitude = 0.0,
-            householderLongitude = 0.0,
             householderAddressDistance = AddressProvider.AddressDistance.NoData,
             subject = "Who is Jesus Christ?"
         ),

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
@@ -660,7 +660,6 @@ fun VisitCardSkeleton() {
         VisitListViewModel.VisitHouseholderState(
             householderId = UUID.randomUUID(),
             householderName = householderName,
-            householderAddress = householderAddress,
             date = LocalDateTime.now(),
             isDone = false,
             hasDrafts = false,
@@ -670,8 +669,11 @@ fun VisitCardSkeleton() {
             hide = false,
             visitId = UUID.randomUUID(),
             type = VisitType.FIRST_VISIT,
-            householderLatitude = 0.0,
-            householderLongitude = 0.0,
+            householderAddressState = VisitListViewModel.HouseholderAddressState.Data(
+                latitude = 0.0,
+                longitude = 0.0,
+                address = householderAddress
+            ),
             householderAddressDistance = AddressProvider.AddressDistance.Medium(300f),
             subject = ""
         )
@@ -867,17 +869,20 @@ private fun VisitCard(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+
+                val addressState = visit.householderAddressState
                 AnimatedVisibility(
-                    visible = !isLoading
+                    visible = !isLoading && addressState is VisitListViewModel.HouseholderAddressState.Data
                 ) {
-                    if (!isLoading && visit.householderAddressDistance !is AddressProvider.AddressDistance.NoData) {
+                    if (addressState is VisitListViewModel.HouseholderAddressState.Data) {
                         IconButton(
                             modifier = Modifier.size(24.dp),
                             onClick = {
-                                val latitude = visit.householderLatitude ?: return@IconButton
-                                val longitude = visit.householderLongitude ?: return@IconButton
-                                val householderAddress = visit.householderAddress
-                                context.launchGoogleMaps(householderAddress, latitude, longitude)
+                                context.launchGoogleMaps(
+                                    addressState.address,
+                                    addressState.latitude,
+                                    addressState.longitude
+                                )
                             }) {
                             Icon(
                                 imageVector = Icons.Rounded.Explore,

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -560,14 +560,18 @@ constructor(
         visitList: List<VisitHouseholderState>
     ): VisitMapState {
         val visitMapData = visitList.mapNotNull { visit ->
-            val latitude = visit.householderLatitude ?: return@mapNotNull null
-            val longitude = visit.householderLongitude ?: return@mapNotNull null
+            if (visit.householderAddressState !is HouseholderAddressState.Data) {
+                return@mapNotNull null
+            }
+            val householderAddress = visit.householderAddressState.address
+            val latitude = visit.householderAddressState.latitude
+            val longitude = visit.householderAddressState.longitude
             val householderDistance = visit.householderAddressDistance.distanceOrNull?.toInt()
 
             VisitMapData(
                 householderName = visit.householderName,
                 visitSubject = visit.subjectPreview,
-                householderAddress = visit.householderAddress,
+                householderAddress = householderAddress,
                 householderLatitude = latitude,
                 householderLongitude = longitude,
                 householderDistance = householderDistance,
@@ -629,10 +633,11 @@ constructor(
         latitude: Double,
         longitude: Double
     ): AddressProvider.AddressDistance {
-        val householderLatitude =
-            householderLatitude ?: return AddressProvider.AddressDistance.NoData
-        val householderLongitude =
-            householderLongitude ?: return AddressProvider.AddressDistance.NoData
+        if (householderAddressState !is HouseholderAddressState.Data) {
+            return AddressProvider.AddressDistance.NoData
+        }
+        val householderLatitude = householderAddressState.latitude
+        val householderLongitude = householderAddressState.longitude
         return addressProvider.calculateDistance(
             startLatitude = latitude,
             startLongitude = longitude,
@@ -718,6 +723,18 @@ constructor(
 
     private val VisitHouseholder.asState: VisitHouseholderState
         get() {
+            val householderAddressState = if (householderAddress.isEmpty()
+                || householderLatitude == null
+                || householderLongitude == null
+            ) {
+                HouseholderAddressState.NoData
+            } else {
+                HouseholderAddressState.Data(
+                    latitude = householderLatitude,
+                    longitude = householderLongitude,
+                    address = householderAddress
+                )
+            }
             return VisitHouseholderState(
                 visitId = visitId,
                 subject = subject,
@@ -727,12 +744,10 @@ constructor(
                 hasDrafts = hasDrafts,
                 householderId = householderId,
                 householderName = householderName,
-                householderAddress = householderAddress,
+                householderAddressState = householderAddressState,
                 isPendingVisitMenuExpanded = false,
                 hasToBeRescheduled = hasToBeRescheduled(date, isDone),
                 type = type,
-                householderLatitude = householderLatitude,
-                householderLongitude = householderLongitude,
                 householderAddressDistance = AddressProvider.AddressDistance.NoData,
                 hide = false
             )
@@ -841,10 +856,8 @@ constructor(
         val hasDrafts: Boolean,
         val householderId: UUID,
         val householderName: String,
-        val householderAddress: String,
-        val householderLatitude: Double?,
-        val householderLongitude: Double?,
         val householderAddressDistance: AddressProvider.AddressDistance,
+        val householderAddressState: HouseholderAddressState,
         val hide: Boolean,
         val isPendingVisitMenuExpanded: Boolean,
         val hasToBeRescheduled: Boolean,
@@ -854,6 +867,15 @@ constructor(
     sealed interface PreviewBackupFileState {
         data object None : PreviewBackupFileState
         data class Previewing(val fileUri: Uri) : PreviewBackupFileState
+    }
+
+    sealed interface HouseholderAddressState {
+        data object NoData : HouseholderAddressState
+        data class Data(
+            val latitude: Double,
+            val longitude: Double,
+            val address: String,
+        ) : HouseholderAddressState
     }
 
     data class UiState(


### PR DESCRIPTION
## 📝 Description
Refactors `VisitHouseholderState` to replace the three always-together nullable fields — `householderAddress`, `householderLatitude`, `householderLongitude` — with a single `HouseholderAddressState` sealed type (`Data` / `NoData`). This makes the "we have coordinates" vs "we don't" cases explicit and keeps an address from ever existing without its coordinates (or vice versa).

While in here I tightened up two smells that came along with the change:

- **Removed the redundant `showAddressOptionsButton` flag.** It only ever mirrored `addressState is Data` (and, in the skeleton, the `isLoading` signal we already had). Keeping it as separate stored state meant two sources of truth that could drift, and it forced an empty `when (NoData) {}` branch in the UI. The maps button now shows when `!isLoading && addressState is Data`.
- **Consistency tidy-ups:** `Data` now orders params `(latitude, longitude, address)` per the universal convention, and `HouseholderAddressState` is a `sealed interface` to match the neighbouring `PreviewBackupFileState`.

The `asState` mapping, `buildVisitMapState`, and `calculateDistance` were updated to read from the new state. The preview provider was ported too: the two addressed visits become `Data`; the Nicodemus entry (previously `distance = NoData`, so it never rendered a maps button) becomes `NoData` to preserve that card variant in screenshots.

Note the rendered output is unchanged — `validateDebugScreenshotTest` passed with no reference-image updates needed.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] UI changes tested on device/emulator (screenshot tests validated — no visual change)
- [x] Follows existing code patterns and conventions