### PR TITLE
Add address options sheet with Google Maps and Uber

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <queries>
         <package android:name="com.google.android.apps.maps" />
+        <package android:name="com.ubercab" />
     </queries>
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt
+++ b/app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt
@@ -23,6 +23,32 @@ fun Context.launchGoogleMaps(label: String, latitude: Double, longitude: Double)
     }
 }
 
+/**
+ * Requests an Uber ride to ([latitude], [longitude]) with [label] as the dropoff nickname.
+ * Pickup defaults to the rider's current location (resolved by Uber). Opens the Uber app via
+ * a `uber://` deep link when installed; otherwise falls back to the `m.uber.com` universal
+ * link in a browser.
+ */
+fun Context.launchUber(label: String, latitude: Double, longitude: Double) {
+    val encodedLabel = Uri.encode(label)
+    val deepLinkParams =
+        "action=setPickup&pickup=my_location" +
+            "&dropoff[latitude]=$latitude&dropoff[longitude]=$longitude&dropoff[nickname]=$encodedLabel"
+
+    val uberUri = Uri.parse("uber://?$deepLinkParams")
+    val uberIntent = Intent(Intent.ACTION_VIEW, uberUri)
+    uberIntent.setPackage("com.ubercab")
+
+    if (uberIntent.resolveActivity(packageManager) != null) {
+        startActivity(uberIntent)
+    } else {
+        // Fallback to the Uber universal web link if the app isn't installed
+        val fallbackUri = Uri.parse("https://m.uber.com/ul/?$deepLinkParams")
+        val fallbackIntent = Intent(Intent.ACTION_VIEW, fallbackUri)
+        startActivity(fallbackIntent)
+    }
+}
+
 fun Context.showShareIntent(shareFileUri: Uri, mime: String) {
     val shareIntent = Intent(Intent.ACTION_SEND).apply {
         type = mime

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
@@ -893,7 +893,7 @@ private fun VisitCard(
                             }) {
                             Icon(
                                 imageVector = Icons.Rounded.Explore,
-                                contentDescription = stringResource(R.string.open_map_directions_content_description),
+                                contentDescription = stringResource(R.string.open_address_options_content_description),
                                 tint = MaterialTheme.colorScheme.primary,
                             )
                         }

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -32,6 +33,7 @@ import androidx.compose.material.icons.rounded.Explore
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.material.icons.rounded.FindInPage
 import androidx.compose.material.icons.rounded.Group
+import androidx.compose.material.icons.rounded.LocalTaxi
 import androidx.compose.material.icons.rounded.LocationOn
 import androidx.compose.material.icons.rounded.Map
 import androidx.compose.material.icons.rounded.Update
@@ -48,6 +50,8 @@ import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -82,8 +86,10 @@ import com.msmobile.visitas.backup.BackupSheet
 import com.msmobile.visitas.backup.BackupViewModel
 import com.msmobile.visitas.extension.OnBackPressed
 import com.msmobile.visitas.extension.RequestLocationPermission
+import com.msmobile.visitas.extension.bottomSheetListItemColors
 import com.msmobile.visitas.extension.isKeyboardOpen
 import com.msmobile.visitas.extension.launchGoogleMaps
+import com.msmobile.visitas.extension.launchUber
 import com.msmobile.visitas.extension.textShimmer
 import com.msmobile.visitas.extension.toString
 import com.msmobile.visitas.extension.tonalButtonColors
@@ -285,6 +291,12 @@ private fun VisitListScreenContent(
             },
             onMapError = onMapError
         )
+        visitListUiState.addressOptionsSheet?.let { address ->
+            AddressOptionsSheet(
+                address = address,
+                onEvent = onVisitListEvent
+            )
+        }
         BibleStudentsSheet(
             isVisible = summaryUiState.isBibleStudentsSheetVisible,
             bibleStudentNames = summaryUiState.bibleStudentNames,
@@ -774,7 +786,6 @@ private fun VisitCard(
     val locale = LocalConfiguration.current.locales[0]
     val isHouseholderAddressNearby =
         visit.householderAddressDistance is AddressProvider.AddressDistance.Nearby
-    val context = LocalContext.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -878,11 +889,7 @@ private fun VisitCard(
                         IconButton(
                             modifier = Modifier.size(24.dp),
                             onClick = {
-                                context.launchGoogleMaps(
-                                    addressState.address,
-                                    addressState.latitude,
-                                    addressState.longitude
-                                )
+                                onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visit))
                             }) {
                             Icon(
                                 imageVector = Icons.Rounded.Explore,
@@ -1165,4 +1172,64 @@ internal fun VisitListScreenPreview(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddressOptionsSheet(
+    address: VisitListViewModel.HouseholderAddressState.Data,
+    onEvent: (VisitListViewModel.UiEvent) -> Unit
+) {
+    val context = LocalContext.current
+    val onDismiss = { onEvent(VisitListViewModel.UiEvent.AddressOptionsDismissed) }
+    PreviewCompatModalSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(modifier = Modifier.navigationBarsPadding()) {
+            ListItem(
+                modifier = Modifier,
+                leadingContent = null,
+                trailingContent = null,
+                overlineContent = { Text(text = stringResource(id = R.string.householder_address)) },
+                supportingContent = null,
+                colors = ListItemDefaults.bottomSheetListItemColors(),
+                elevation = ListItemDefaults.elevation(),
+                content = { Text(text = address.address) },
+            )
+            HorizontalDivider()
+            AddressOptionItem(
+                icon = Icons.Rounded.Explore,
+                label = stringResource(id = R.string.address_action_google_maps)
+            ) {
+                context.launchGoogleMaps(address.address, address.latitude, address.longitude)
+                onDismiss()
+            }
+            AddressOptionItem(
+                icon = Icons.Rounded.LocalTaxi,
+                label = stringResource(id = R.string.address_action_uber)
+            ) {
+                context.launchUber(address.address, address.latitude, address.longitude)
+                onDismiss()
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddressOptionItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick),
+        leadingContent = { Icon(imageVector = icon, contentDescription = null) },
+        trailingContent = null,
+        overlineContent = null,
+        supportingContent = null,
+        colors = ListItemDefaults.bottomSheetListItemColors(),
+        elevation = ListItemDefaults.elevation(),
+        content = { Text(text = label) },
+    )
 }

--- a/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
+++ b/app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt
@@ -140,6 +140,8 @@ constructor(
             is UiEvent.RestorePreviewedBackupDialogDismissed -> handleRestorePreviewedBackupDialogDismissed()
             is UiEvent.VisitMapSheetClicked -> handleVisitMapSheetClicked()
             is UiEvent.VisitMapSheetDismissed -> handleVisitMapSheetDismissed()
+            is UiEvent.AddressOptionsClicked -> handleAddressOptionsClicked(uiEvent.visit)
+            is UiEvent.AddressOptionsDismissed -> handleAddressOptionsDismissed()
         }
     }
 
@@ -441,6 +443,19 @@ constructor(
             copy(
                 showVisitMapSheet = false
             )
+        }
+    }
+
+    private fun handleAddressOptionsClicked(visit: VisitHouseholderState) {
+        val address = visit.householderAddressState as? HouseholderAddressState.Data ?: return
+        newState {
+            copy(addressOptionsSheet = address)
+        }
+    }
+
+    private fun handleAddressOptionsDismissed() {
+        newState {
+            copy(addressOptionsSheet = null)
         }
     }
 
@@ -817,6 +832,8 @@ constructor(
         data class TabSelected(val tabIndex: Int) : UiEvent()
         data class SearchChanged(val filter: String) : UiEvent()
         data class PendingVisitMenuClicked(val visit: VisitHouseholderState) : UiEvent()
+        data class AddressOptionsClicked(val visit: VisitHouseholderState) : UiEvent()
+        data object AddressOptionsDismissed : UiEvent()
         data class RescheduleVisitToday(val visit: VisitHouseholderState) : UiEvent()
         data class RescheduleVisitTomorrow(val visit: VisitHouseholderState) : UiEvent()
         data class RescheduleVisitSelected(
@@ -896,7 +913,8 @@ constructor(
         val currentCoordinates: Pair<Double, Double>,
         val visitMapState: VisitMapState,
         val previewBackupFileState: PreviewBackupFileState,
-        val visitMapEngine: VisitMapEngineOption = VisitMapEngineOption.MapLibre
+        val visitMapEngine: VisitMapEngineOption = VisitMapEngineOption.MapLibre,
+        val addressOptionsSheet: HouseholderAddressState.Data? = null
     )
 
     companion object {

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -136,7 +136,7 @@
     <string name="show_visits_map_content_description">Mostrar mapa de visitas</string>
     <string name="no_visits_found_icon_content_description">No se encontraron visitas</string>
     <string name="filter_visits_content_description">Filtrar visitas</string>
-    <string name="open_map_directions_content_description">Abrir direcciones en el mapa</string>
+    <string name="open_address_options_content_description">Abrir opciones de dirección</string>
     <string name="permission_rationale_icon_content_description">Permiso requerido</string>
     <string name="search_icon_content_description">Buscar</string>
     <string name="restore_backup_icon_content_description">Restaurar copia de seguridad</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -10,6 +10,8 @@
     <string name="phone_action_whatsapp">WhatsApp</string>
     <string name="phone_action_edit">Editar número</string>
     <string name="householder_address">Dirección</string>
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
     <string name="visit_date">Fecha de la visita</string>
     <string name="visit_subject">Tema</string>
     <string name="cancel">Cancelar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -135,7 +135,7 @@
     <string name="show_visits_map_content_description">Exibir mapa de visitas</string>
     <string name="no_visits_found_icon_content_description">Nenhuma visita encontrada</string>
     <string name="filter_visits_content_description">Filtrar visitas</string>
-    <string name="open_map_directions_content_description">Abrir rotas no mapa</string>
+    <string name="open_address_options_content_description">Abrir opções de endereço</string>
     <string name="permission_rationale_icon_content_description">Permissão necessária</string>
     <string name="search_icon_content_description">Pesquisar</string>
     <string name="restore_backup_icon_content_description">Restaurar backup</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -9,6 +9,8 @@
     <string name="phone_action_whatsapp">WhatsApp</string>
     <string name="phone_action_edit">Editar número</string>
     <string name="householder_address">Endereço</string>
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
     <string name="visit_date">Data da visita</string>
     <string name="visit_subject">Assunto</string>
     <string name="cancel">Cancelar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="phone_action_whatsapp">WhatsApp</string>
     <string name="phone_action_edit">Edit number</string>
     <string name="householder_address">Address</string>
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
     <string name="visit_date">Visit date</string>
     <string name="visit_subject">Subject</string>
     <string name="cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,7 +137,7 @@
     <string name="show_visits_map_content_description">Show visits map</string>
     <string name="no_visits_found_icon_content_description">No visits found</string>
     <string name="filter_visits_content_description">Filter visits</string>
-    <string name="open_map_directions_content_description">Open map directions</string>
+    <string name="open_address_options_content_description">Open address options</string>
     <string name="permission_rationale_icon_content_description">Permission required</string>
     <string name="search_icon_content_description">Search</string>
     <string name="restore_backup_icon_content_description">Restore backup</string>

--- a/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
@@ -15,6 +15,8 @@ import com.msmobile.visitas.util.UserLocationProvider
 import com.msmobile.visitas.util.VisitMapAdapter
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
@@ -216,6 +218,60 @@ class VisitListViewModelTest {
 
         // Assert
         assertFalse(viewModel.uiState.value.showVisitMapSheet)
+    }
+
+    @Test
+    fun `onEvent with AddressOptionsClicked shows sheet with the visit's address data`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+        val visitWithAddress = requireNotNull(
+            viewModel.uiState.value.visitList.find { it.visitId == SECOND_VISIT_ID }
+        )
+
+        // Act
+        viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithAddress))
+
+        // Assert
+        val sheet = viewModel.uiState.value.addressOptionsSheet
+        assertNotNull(sheet)
+        assertEquals("Address 2", sheet?.address)
+        assertEquals(40.7128, sheet?.latitude)
+        assertEquals(-74.0060, sheet?.longitude)
+    }
+
+    @Test
+    fun `onEvent with AddressOptionsClicked ignores visit without address data`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+        val visitWithoutAddress = requireNotNull(
+            viewModel.uiState.value.visitList.find { it.visitId == FIRST_VISIT_ID }
+        )
+
+        // Act
+        viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithoutAddress))
+
+        // Assert
+        assertNull(viewModel.uiState.value.addressOptionsSheet)
+    }
+
+    @Test
+    fun `onEvent with AddressOptionsDismissed hides the sheet`() {
+        // Arrange
+        val viewModel = createViewModel()
+        viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+        val visitWithAddress = requireNotNull(
+            viewModel.uiState.value.visitList.find { it.visitId == SECOND_VISIT_ID }
+        )
+        viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithAddress))
+        assertNotNull(viewModel.uiState.value.addressOptionsSheet)
+
+        // Act
+        viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsDismissed)
+
+        // Assert
+        assertNull(viewModel.uiState.value.addressOptionsSheet)
     }
 
     @Test

--- a/docs/superpowers/plans/2026-07-09-address-options-sheet.md
+++ b/docs/superpowers/plans/2026-07-09-address-options-sheet.md
@@ -1,0 +1,426 @@
+# Address Options Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct Google-Maps launch on each visit row with a bottom sheet offering "Google Maps" and "Uber" (deep-link ride request) options.
+
+**Architecture:** A new `Context.launchUber` intent extension mirrors the existing `launchGoogleMaps`. The list ViewModel gains a nullable `addressOptionsSheet` field (holding the tapped row's address), driven by two new `UiEvent`s — following the existing screen-level `VisitMapSheet` pattern. The row's icon dispatches an event instead of launching Maps directly; a new `AddressOptionsSheet` composable (a copy of `PhoneOptionsSheet`) renders the two actions.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit + Mockito (kotlin), Android intents.
+
+---
+
+## File Structure
+
+- **Modify** `app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt` — add `launchUber`.
+- **Modify** `app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt` — `addressOptionsSheet` state field, two `UiEvent`s, dispatch entries, two handlers.
+- **Modify** `app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt` — row `onClick`, `AddressOptionsSheet` + `AddressOptionItem` composables, imports.
+- **Modify** `app/src/main/res/values/strings.xml` (+ `values-b+es+419/strings.xml`, `values-pt-rBR/strings.xml`) — two new strings.
+- **Modify** `app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt` — tests for the new events.
+
+---
+
+## Task 1: Uber deep-link extension
+
+Follows the untested `launchGoogleMaps` precedent (no unit test — the extension is a thin intent builder, consistent with the rest of `ContextExtension.kt`).
+
+**Files:**
+- Modify: `app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt`
+
+- [ ] **Step 1: Add `launchUber` after `launchGoogleMaps`**
+
+Insert this function immediately after the closing brace of `launchGoogleMaps` (after line 24):
+
+```kotlin
+/**
+ * Requests an Uber ride to ([latitude], [longitude]) with [label] as the dropoff nickname.
+ * Pickup defaults to the rider's current location (resolved by Uber). Opens the Uber app via
+ * a `uber://` deep link when installed; otherwise falls back to the `m.uber.com` universal
+ * link in a browser.
+ */
+fun Context.launchUber(label: String, latitude: Double, longitude: Double) {
+    val encodedLabel = Uri.encode(label)
+    val deepLinkParams =
+        "action=setPickup&pickup=my_location" +
+            "&dropoff[latitude]=$latitude&dropoff[longitude]=$longitude&dropoff[nickname]=$encodedLabel"
+
+    val uberUri = Uri.parse("uber://?$deepLinkParams")
+    val uberIntent = Intent(Intent.ACTION_VIEW, uberUri)
+    uberIntent.setPackage("com.ubercab")
+
+    if (uberIntent.resolveActivity(packageManager) != null) {
+        startActivity(uberIntent)
+    } else {
+        // Fallback to the Uber universal web link if the app isn't installed
+        val fallbackUri = Uri.parse("https://m.uber.com/ul/?$deepLinkParams")
+        val fallbackIntent = Intent(Intent.ACTION_VIEW, fallbackUri)
+        startActivity(fallbackIntent)
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt
+git commit -m "Add launchUber intent extension for ride requests"
+```
+
+---
+
+## Task 2: ViewModel state, events, and handlers (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt`
+- Test: `app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `VisitListViewModelTest.kt`, add these imports near the other `junit.framework.TestCase` imports (after line 18):
+
+```kotlin
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+```
+
+Then add these three tests after the `VisitMapSheetDismissed` test (after line 219). `SECOND_VISIT_ID` (coordinates set → `Data`) and `FIRST_VISIT_ID` (null coordinates → `NoData`) are the fixtures already built by `createVisitHouseholderList()`:
+
+```kotlin
+@Test
+fun `onEvent with AddressOptionsClicked shows sheet with the visit's address data`() {
+    // Arrange
+    val viewModel = createViewModel()
+    viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+    val visitWithAddress = requireNotNull(
+        viewModel.uiState.value.visitList.find { it.visitId == SECOND_VISIT_ID }
+    )
+
+    // Act
+    viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithAddress))
+
+    // Assert
+    val sheet = viewModel.uiState.value.addressOptionsSheet
+    assertNotNull(sheet)
+    assertEquals("Address 2", sheet?.address)
+    assertEquals(40.7128, sheet?.latitude)
+    assertEquals(-74.0060, sheet?.longitude)
+}
+
+@Test
+fun `onEvent with AddressOptionsClicked ignores visit without address data`() {
+    // Arrange
+    val viewModel = createViewModel()
+    viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+    val visitWithoutAddress = requireNotNull(
+        viewModel.uiState.value.visitList.find { it.visitId == FIRST_VISIT_ID }
+    )
+
+    // Act
+    viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithoutAddress))
+
+    // Assert
+    assertNull(viewModel.uiState.value.addressOptionsSheet)
+}
+
+@Test
+fun `onEvent with AddressOptionsDismissed hides the sheet`() {
+    // Arrange
+    val viewModel = createViewModel()
+    viewModel.onEvent(VisitListViewModel.UiEvent.ViewCreated)
+    val visitWithAddress = requireNotNull(
+        viewModel.uiState.value.visitList.find { it.visitId == SECOND_VISIT_ID }
+    )
+    viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visitWithAddress))
+    assertNotNull(viewModel.uiState.value.addressOptionsSheet)
+
+    // Act
+    viewModel.onEvent(VisitListViewModel.UiEvent.AddressOptionsDismissed)
+
+    // Assert
+    assertNull(viewModel.uiState.value.addressOptionsSheet)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.msmobile.visitas.visit.VisitListViewModelTest"`
+Expected: FAIL — compilation error / unresolved reference `AddressOptionsClicked`, `AddressOptionsDismissed`, and `addressOptionsSheet`.
+
+- [ ] **Step 3: Add the `addressOptionsSheet` field to `UiState`**
+
+In `VisitListViewModel.kt`, in the `UiState` data class (around line 899), add the field as the new last parameter (with a default so the state initializer needs no change), after `visitMapEngine`:
+
+```kotlin
+        val visitMapEngine: VisitMapEngineOption = VisitMapEngineOption.MapLibre,
+        val addressOptionsSheet: HouseholderAddressState.Data? = null
+    )
+```
+
+- [ ] **Step 4: Add the two `UiEvent`s**
+
+In the `sealed class UiEvent` block, add after `PendingVisitMenuClicked` (line 819):
+
+```kotlin
+        data class AddressOptionsClicked(val visit: VisitHouseholderState) : UiEvent()
+        data object AddressOptionsDismissed : UiEvent()
+```
+
+- [ ] **Step 5: Add dispatch entries in `onEvent`**
+
+In the `onEvent` `when` block, add after the `VisitMapSheetDismissed` line (line 142):
+
+```kotlin
+            is UiEvent.AddressOptionsClicked -> handleAddressOptionsClicked(uiEvent.visit)
+            is UiEvent.AddressOptionsDismissed -> handleAddressOptionsDismissed()
+```
+
+- [ ] **Step 6: Add the two handlers**
+
+Add these functions immediately after `handleVisitMapSheetDismissed()` (after line 445):
+
+```kotlin
+    private fun handleAddressOptionsClicked(visit: VisitHouseholderState) {
+        val address = visit.householderAddressState as? HouseholderAddressState.Data ?: return
+        newState {
+            copy(addressOptionsSheet = address)
+        }
+    }
+
+    private fun handleAddressOptionsDismissed() {
+        newState {
+            copy(addressOptionsSheet = null)
+        }
+    }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.msmobile.visitas.visit.VisitListViewModelTest"`
+Expected: PASS (all tests, including the three new ones).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt app/src/test/java/com/msmobile/visitas/visit/VisitListViewModelTest.kt
+git commit -m "Add address options sheet state to visit list ViewModel"
+```
+
+---
+
+## Task 3: String resources
+
+**Files:**
+- Modify: `app/src/main/res/values/strings.xml`
+- Modify: `app/src/main/res/values-b+es+419/strings.xml`
+- Modify: `app/src/main/res/values-pt-rBR/strings.xml`
+
+The header reuses the existing `householder_address` string. Only two new brand-name strings are needed; as proper nouns they are identical across locales.
+
+- [ ] **Step 1: Add strings to the default locale**
+
+In `app/src/main/res/values/strings.xml`, add near the other `phone_action_*` strings (after line 9):
+
+```xml
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
+```
+
+- [ ] **Step 2: Add the same strings to `values-b+es+419/strings.xml`**
+
+Add after the `phone_action_call` string (after line 8):
+
+```xml
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
+```
+
+- [ ] **Step 3: Add the same strings to `values-pt-rBR/strings.xml`**
+
+Add after the `phone_action_call` string (after line 7):
+
+```xml
+    <string name="address_action_google_maps">Google Maps</string>
+    <string name="address_action_uber">Uber</string>
+```
+
+- [ ] **Step 4: Verify resources compile**
+
+Run: `./gradlew :app:processDebugResources`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/res/values/strings.xml app/src/main/res/values-b+es+419/strings.xml app/src/main/res/values-pt-rBR/strings.xml
+git commit -m "Add address action strings for Google Maps and Uber options"
+```
+
+---
+
+## Task 4: Row wiring and the sheet composable
+
+**Files:**
+- Modify: `app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt`
+
+- [ ] **Step 1: Add the required imports**
+
+In `VisitListScreen.kt`, add these imports in the correct alphabetical positions among the existing imports:
+
+```kotlin
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material.icons.rounded.LocalTaxi
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import com.msmobile.visitas.extension.bottomSheetListItemColors
+import com.msmobile.visitas.extension.launchUber
+```
+
+(`clickable`, `Column`, `Explore`, `ExperimentalMaterial3Api`, `HorizontalDivider`, `Icon`, `LocalContext`, `launchGoogleMaps`, `rememberModalBottomSheetState`, `stringResource`, `Text`, and `PreviewCompatModalSheet` are already imported.)
+
+- [ ] **Step 2: Change the row icon to open the sheet**
+
+Replace the `IconButton`'s `onClick` at `VisitListScreen.kt:880-886` — currently:
+
+```kotlin
+                            onClick = {
+                                context.launchGoogleMaps(
+                                    addressState.address,
+                                    addressState.latitude,
+                                    addressState.longitude
+                                )
+                            }) {
+```
+
+with:
+
+```kotlin
+                            onClick = {
+                                onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visit))
+                            }) {
+```
+
+(`onEvent` and `visit` are already in scope in this row composable.)
+
+- [ ] **Step 3: Render the sheet at screen level**
+
+In the screen-level composable, immediately after the `VisitMapSheet(...)` call block (which ends at line 287), add:
+
+```kotlin
+        visitListUiState.addressOptionsSheet?.let { address ->
+            AddressOptionsSheet(
+                address = address,
+                onEvent = onVisitListEvent
+            )
+        }
+```
+
+- [ ] **Step 4: Add the `AddressOptionsSheet` and `AddressOptionItem` composables**
+
+Add these two private composables at the end of the file (after the last top-level composable, e.g. after the `VisitMapSheet` composable that ends the file region around line 966+). Place them at file top level (not nested):
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddressOptionsSheet(
+    address: VisitListViewModel.HouseholderAddressState.Data,
+    onEvent: (VisitListViewModel.UiEvent) -> Unit
+) {
+    val context = LocalContext.current
+    val onDismiss = { onEvent(VisitListViewModel.UiEvent.AddressOptionsDismissed) }
+    PreviewCompatModalSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(modifier = Modifier.navigationBarsPadding()) {
+            ListItem(
+                modifier = Modifier,
+                leadingContent = null,
+                trailingContent = null,
+                overlineContent = { Text(text = stringResource(id = R.string.householder_address)) },
+                supportingContent = null,
+                colors = ListItemDefaults.bottomSheetListItemColors(),
+                elevation = ListItemDefaults.elevation(),
+                content = { Text(text = address.address) },
+            )
+            HorizontalDivider()
+            AddressOptionItem(
+                icon = Icons.Rounded.Explore,
+                label = stringResource(id = R.string.address_action_google_maps)
+            ) {
+                context.launchGoogleMaps(address.address, address.latitude, address.longitude)
+                onDismiss()
+            }
+            AddressOptionItem(
+                icon = Icons.Rounded.LocalTaxi,
+                label = stringResource(id = R.string.address_action_uber)
+            ) {
+                context.launchUber(address.address, address.latitude, address.longitude)
+                onDismiss()
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddressOptionItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick),
+        leadingContent = { Icon(imageVector = icon, contentDescription = null) },
+        trailingContent = null,
+        overlineContent = null,
+        supportingContent = null,
+        colors = ListItemDefaults.bottomSheetListItemColors(),
+        elevation = ListItemDefaults.elevation(),
+        content = { Text(text = label) },
+    )
+}
+```
+
+- [ ] **Step 5: Verify the app compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt
+git commit -m "Show address options sheet with Google Maps and Uber actions"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: `BUILD SUCCESSFUL`, all tests pass.
+
+- [ ] **Step 2: Assemble a debug build**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Manual smoke check (device/emulator)**
+
+Use the `verify` or `run` skill to launch the app, open the visit list, tap a row's map icon, and confirm:
+- The sheet shows the address header + "Google Maps" and "Uber" rows.
+- "Google Maps" opens Maps to the householder location (existing behavior).
+- "Uber" opens the Uber app (or `m.uber.com` if not installed) with the dropoff pre-filled.
+
+---
+
+## Notes
+
+- The `AddressOptionItem` composable is an intentional copy of `PhoneOptionItem` (in `VisitDetailScreen.kt`) rather than a shared helper — the two screens keep their own private option-item composables, matching the existing per-screen convention. If a future task consolidates them, that is out of scope here.
+- No instrumentation/intent tests are added for `launchUber` or the composables, matching the existing untested precedent for `launchGoogleMaps` and `PhoneOptionsSheet`.

--- a/docs/superpowers/specs/2026-07-09-address-options-sheet-design.md
+++ b/docs/superpowers/specs/2026-07-09-address-options-sheet-design.md
@@ -1,0 +1,147 @@
+# Address Options Sheet (Google Maps + Uber) — Design
+
+**Date:** 2026-07-09
+**Status:** Approved (pending spec review)
+
+## Summary
+
+Today, the address button on each visit row in `VisitListScreen` launches Google Maps
+directly. This change replaces that single action with a bottom sheet offering two options:
+
+- **Google Maps** — current behavior (directions to the householder's address).
+- **Uber** — deep-links into the Uber app with the householder's location pre-filled as
+  the dropoff, requesting a ride.
+
+The sheet mirrors the existing `PhoneOptionsSheet` in `VisitDetailScreen`, and the sheet
+state follows the existing screen-level sheet pattern (`VisitMapSheet`) in the list
+ViewModel.
+
+## Current behavior (baseline)
+
+`VisitListScreen.kt:878-892` — the row's `IconButton` (a `Icons.Rounded.Explore` icon,
+visible only when `householderAddressState is HouseholderAddressState.Data`) calls:
+
+```kotlin
+context.launchGoogleMaps(addressState.address, addressState.latitude, addressState.longitude)
+```
+
+`ContextExtension.kt:9` — `launchGoogleMaps` builds a `geo:` URI targeting
+`com.google.android.apps.maps`, and falls back to a `https://www.google.com/maps/...`
+browser URL via `resolveActivity` when Maps isn't installed.
+
+## Design
+
+### 1. Uber deep-link extension
+
+Add `Context.launchUber(label, latitude, longitude)` to `ContextExtension.kt`, mirroring
+`launchGoogleMaps`:
+
+- Primary intent — Uber app deep link:
+  `uber://?action=setPickup&pickup=my_location&dropoff[latitude]=$latitude&dropoff[longitude]=$longitude&dropoff[nickname]=$encodedLabel`,
+  package `com.ubercab`. `label` is URI-encoded with `Uri.encode`, same as `launchGoogleMaps`.
+- Fallback — if `resolveActivity(packageManager)` is null, open the universal web link in a
+  browser: `https://m.uber.com/ul/?action=setPickup&pickup=my_location&dropoff[latitude]=$latitude&dropoff[longitude]=$longitude&dropoff[nickname]=$encodedLabel`.
+
+Same structure and error-handling shape as `launchGoogleMaps`, so it is a drop-in sibling.
+Pickup defaults to `my_location` (the rider's current location, resolved by Uber).
+
+### 2. Screen-level sheet state (VisitListViewModel)
+
+Follow the existing screen-level single-sheet pattern (`VisitMapSheet`) rather than a
+per-row flag — the sheet renders once at the screen level and holds the tapped row's
+address. A per-row boolean was rejected: it would render one sheet per row and is
+inconsistent with how other modal sheets work here.
+
+**`UiState`** — add one nullable field (null = hidden; no extra boolean needed):
+
+```kotlin
+val addressOptionsSheet: HouseholderAddressState.Data? = null
+```
+
+Add `addressOptionsSheet = null` to the preview/default `UiState` initializer alongside the
+other sheet defaults (e.g. next to `showVisitMapSheet = false`).
+
+**`UiEvent`** — two new events:
+
+```kotlin
+data class AddressOptionsClicked(val visit: VisitHouseholderState) : UiEvent()
+data object AddressOptionsDismissed : UiEvent()
+```
+
+**Handlers** (dispatched from `onEvent`):
+
+- `handleAddressOptionsClicked(visit)` — if `visit.householderAddressState` is
+  `HouseholderAddressState.Data`, set `addressOptionsSheet` to that `Data`; otherwise no-op.
+- `handleAddressOptionsDismissed()` — set `addressOptionsSheet = null`.
+
+### 3. Row wiring (VisitListScreen)
+
+The row `IconButton` (`:878-892`) keeps the same `Icons.Rounded.Explore` icon and
+`AnimatedVisibility` gating. Its `onClick` changes from calling `context.launchGoogleMaps(...)`
+directly to:
+
+```kotlin
+onClick = { onEvent(VisitListViewModel.UiEvent.AddressOptionsClicked(visit)) }
+```
+
+`onEvent` and `visit` are already in scope at that row.
+
+### 4. The sheet composable
+
+Add `AddressOptionsSheet(address, onEvent)` at screen level (beside `VisitMapSheet`, around
+`VisitListScreen.kt:278`), driven by `uiState.addressOptionsSheet`:
+
+```kotlin
+uiState.addressOptionsSheet?.let { address ->
+    AddressOptionsSheet(address = address, onEvent = onVisitListEvent)
+}
+```
+
+Built the same way as `PhoneOptionsSheet` (`VisitDetailScreen.kt:299`):
+
+- `PreviewCompatModalSheet` with `rememberModalBottomSheetState(skipPartiallyExpanded = true)`,
+  `onDismissRequest` → `onEvent(AddressOptionsDismissed)`.
+- `Column` with `navigationBarsPadding()`.
+- Header `ListItem` (bottom-sheet colors): `overlineContent` = `stringResource(R.string.householder_address)`,
+  `content` = the address text.
+- `HorizontalDivider`.
+- Two rows via a local `AddressOptionItem(icon, label, onClick)` helper (a copy of
+  `PhoneOptionItem`):
+  - **Google Maps** — `Icons.Rounded.Explore`, label `R.string.address_action_google_maps`
+    → `context.launchGoogleMaps(address.address, address.latitude, address.longitude)` then dismiss.
+  - **Uber** — `Icons.Rounded.LocalTaxi`, label `R.string.address_action_uber`
+    → `context.launchUber(address.address, address.latitude, address.longitude)` then dismiss.
+
+`context` comes from `LocalContext.current` inside the composable, same as `PhoneOptionsSheet`.
+Dismiss is `onEvent(AddressOptionsDismissed)`.
+
+### 5. Strings
+
+Reuse the existing `householder_address` string for the header. Add two new brand-name
+strings to all three locale files (`values/`, `values-b+es+419/`, `values-pt-rBR/`). As
+proper nouns they are identical across locales:
+
+- `address_action_google_maps` → `Google Maps`
+- `address_action_uber` → `Uber`
+
+### 6. Testing
+
+- `VisitListViewModel` unit test: `AddressOptionsClicked` on a row whose
+  `householderAddressState` is `Data` sets `addressOptionsSheet` to that `Data`; on a `NoData`
+  row it stays null; `AddressOptionsDismissed` clears it back to null.
+- The `Context` extensions and composables follow existing untested UI-helper precedent
+  (`launchGoogleMaps` has no test), so no intent/instrumentation tests are added.
+
+## Files touched
+
+- `app/src/main/java/com/msmobile/visitas/extension/ContextExtension.kt` — add `launchUber`.
+- `app/src/main/java/com/msmobile/visitas/visit/VisitListViewModel.kt` — state field, events, handlers.
+- `app/src/main/java/com/msmobile/visitas/visit/VisitListScreen.kt` — row onClick, `AddressOptionsSheet`, `AddressOptionItem`.
+- `app/src/main/res/values/strings.xml` (+ `values-b+es+419/`, `values-pt-rBR/`) — two new strings.
+- ViewModel test file for `VisitListViewModel`.
+
+## Out of scope (YAGNI)
+
+- Additional address actions (Waze, copy address, share). Only Google Maps + Uber.
+- Uber SDK / account integration or ride-status tracking — deep link only.
+- Changing the detail-screen phone sheet.


### PR DESCRIPTION
## 📝 Description
Tapping a visit row's map icon now opens a bottom sheet offering two ways to reach the householder's address, instead of launching Google Maps directly:
- **Google Maps** — existing directions behavior.
- **Uber** — deep-links into the Uber app with the householder location pre-filled as the dropoff (pickup defaults to the rider's current location), falling back to `m.uber.com` in a browser when the app isn't installed.

The sheet mirrors the existing `PhoneOptionsSheet` pattern, and its visibility is driven by a nullable `addressOptionsSheet` field on the list `UiState` (following the existing screen-level `VisitMapSheet` pattern). `com.ubercab` was added to the manifest `<queries>` block so the native Uber deep link resolves under the app's target SDK (36).

## 🐞 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

Design spec: `docs/superpowers/specs/2026-07-09-address-options-sheet-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-09-address-options-sheet.md`

> ⚠️ **Not yet verified on a device/emulator** — the sheet render and the Google Maps / Uber intent launches still need a manual smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)