### PR TITLE
Support comma decimal separator in LatLongParser

### DIFF
--- a/app/src/main/java/com/msmobile/visitas/util/LatLongParser.kt
+++ b/app/src/main/java/com/msmobile/visitas/util/LatLongParser.kt
@@ -13,6 +13,12 @@ class LatLongParser @Inject constructor() {
         """^\s*(-?\d+(?:\.\d+)?)\s*[,\s]\s*(-?\d+(?:\.\d+)?)\s*$"""
     )
 
+    // Matches "lat,long" where each number uses a comma as decimal separator,
+    // e.g. "-28,6497173,-49,4233284" or "-28,6497173 -49,4233284".
+    private val commaDecimalPattern = Regex(
+        """^\s*(-?\d+,\d+)\s*[,\s]\s*(-?\d+,\d+)\s*$"""
+    )
+
     // Ordered list of patterns used to extract a coordinate pair from within a
     // larger string such as a map URL. Each pattern captures latitude in group 1
     // and longitude in group 2. Patterns require decimal coordinates so unrelated
@@ -34,6 +40,13 @@ class LatLongParser @Inject constructor() {
     fun parse(input: String): Result<LatLong> {
         plainPattern.matchEntire(input)?.let { match ->
             return buildResult(match.groupValues[1], match.groupValues[2])
+        }
+
+        commaDecimalPattern.matchEntire(input)?.let { match ->
+            return buildResult(
+                match.groupValues[1].replace(',', '.'),
+                match.groupValues[2].replace(',', '.')
+            )
         }
 
         for (pattern in urlPatterns) {

--- a/app/src/test/java/com/msmobile/visitas/util/LatLongParserTest.kt
+++ b/app/src/test/java/com/msmobile/visitas/util/LatLongParserTest.kt
@@ -17,6 +17,20 @@ class LatLongParserTest {
     }
 
     @Test
+    fun `parses comma separated coordinates using comma decimal separator`() {
+        val result = parser.parse("-28,6497173,-49,4233284")
+
+        assertEquals(LatLong(-28.6497173, -49.4233284), result.getOrNull())
+    }
+
+    @Test
+    fun `parses space separated coordinates using comma decimal separator`() {
+        val result = parser.parse("-28,6497173 -49,4233284")
+
+        assertEquals(LatLong(-28.6497173, -49.4233284), result.getOrNull())
+    }
+
+    @Test
     fun `parses plain space separated coordinates`() {
         val result = parser.parse("40.7128 -74.0060")
 


### PR DESCRIPTION
## 📝 Description
- Add support for comma-decimal-separator coordinate formats in `LatLongParser` (e.g. `-28,6497173,-49,4233284` and `-28,6497173 -49,4233284`)
- Rename two placeholder test names (`tc1641`, `tc1642`) to describe the behavior they cover

## 🐞 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions