### PR TITLE
Enable parallel sync for Gradle 9.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,6 @@ org.gradle.configuration-cache=true
 kotlin.incremental=true
 ksp.incremental=true
 android.experimental.enableScreenshotTest=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## 📝 Description
- Enables parallel tooling sync for Gradle by setting `org.gradle.tooling.parallel=true` in `gradle.properties`, taking advantage of the parallel sync support introduced in Gradle 9.4+ to speed up project sync.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

<!-- ## 📷 Screenshots -->
<!-- <img src="" width=300> -->

<!-- ## 🔗 Related Issues -->

<!-- Link any related issues: Fixes #123, Closes #456 -->

## ☑️ Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8vQA7q9PVCcEqKi7eUP7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8vQA7q9PVCcEqKi7eUP7R)_