### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version configuration
 # Update versionName here for new releases
-versionName=1.9.0
+versionName=1.10.0


### PR DESCRIPTION
Automated version bump after cutting `release/1.9.0`.

To override with a major bump, edit `version.properties` in this PR before merging.