### PR TITLE
Add 14-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     target-branch: "master"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14
     rebase-strategy: "auto"
     allow:
       - dependency-type: "all"


### PR DESCRIPTION
## 📝 Description
- Configure Dependabot to only open update PRs for dependency versions that have been released for more than 14 days.
- Adds a `cooldown` block with `default-days: 14` to the existing Gradle update configuration in `.github/dependabot.yml`. Because `default-days` applies to every semver update type (major, minor, and patch), Dependabot will wait until a release has been publicly available for at least 14 days before proposing the upgrade — reducing exposure to regressions in freshly published releases.

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors
- [ ] Tests pass locally
- [ ] UI changes tested on device/emulator
- [x] Follows existing code patterns and conventions

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzWocT5AgDbDF1711k2eCM)_