### PR TITLE
Verify exported Room schemas in CI

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -67,11 +67,15 @@ jobs:
           ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      # Room exports its schema JSONs during KSP compilation, so the build above
-      # already regenerated app/schemas — no emulator or app launch needed. This
-      # only checks the regenerated files match what the PR committed.
+      # Room exports its schema JSONs during KSP compilation — no emulator or app
+      # launch needed. The script force-re-runs the export (the build above
+      # restores KSP from the cache, which skips it) and then checks the result
+      # matches what the PR committed.
       - name: Verify Room Schemas Are Committed
         run: sh scripts/verify-room-schemas.sh
+        env:
+          ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -67,6 +67,12 @@ jobs:
           ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+      # Room exports its schema JSONs during KSP compilation, so the build above
+      # already regenerated app/schemas — no emulator or app launch needed. This
+      # only checks the regenerated files match what the PR committed.
+      - name: Verify Room Schemas Are Committed
+        run: sh scripts/verify-room-schemas.sh
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/regenerate-room-schemas.yml
+++ b/.github/workflows/regenerate-room-schemas.yml
@@ -64,20 +64,14 @@ jobs:
             gradle-${{ runner.os }}-
             gradle-
 
-      # kspDebugKotlin is what generates the schemas; the room plugin's copy
-      # task is wired as its finalizer. Assembling the whole APK is not needed.
+      # The script runs the KSP + copyRoomSchemas tasks with --rerun and fails if
+      # the export produced nothing, so a cache hit can't turn this into a silent
+      # no-op. Assembling the whole APK is not needed.
       - name: Regenerate Room schemas
-        run: ./gradlew :app:kspDebugKotlin
+        run: sh scripts/verify-room-schemas.sh --export-only
         env:
           ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-
-      - name: Fail if no schema was exported
-        run: |
-          if [ -z "$(ls -A app/schemas 2>/dev/null)" ]; then
-            echo "ERROR: app/schemas is empty — the build exported no Room schemas."
-            exit 1
-          fi
 
       - name: Commit and push updated schemas
         run: |

--- a/.github/workflows/regenerate-room-schemas.yml
+++ b/.github/workflows/regenerate-room-schemas.yml
@@ -1,0 +1,92 @@
+name: Regenerate Room Schemas
+
+# Manually-dispatchable job that regenerates the Room schema JSONs under
+# app/schemas for a given branch and commits them back. Useful when the
+# "Verify Room Schemas Are Committed" check in PR Build fails because a
+# database version bump or migration needs its exported schema.
+#
+# Room exports schemas at compile time (the androidx.room Gradle plugin copies
+# the KSP output into app/schemas), so this needs no emulator or app launch.
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to regenerate Room schemas on'
+        required: true
+        type: string
+
+concurrency:
+  group: regenerate-room-schemas-${{ github.event.inputs.target_branch }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate Room Schemas
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+          # PAT so the commit-back push re-triggers the PR Build check
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Create Google Services JSON
+        env:
+          GOOGLE_SERVICES_DEBUG: ${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}
+        run: |
+          mkdir -p app/src/debug
+          printf '%s' "$GOOGLE_SERVICES_DEBUG" > app/src/debug/google-services.json
+          if [ ! -f "app/src/debug/google-services.json" ]; then
+            echo "ERROR: google-services.json was not created"
+            exit 1
+          fi
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+            gradle-
+
+      # kspDebugKotlin is what generates the schemas; the room plugin's copy
+      # task is wired as its finalizer. Assembling the whole APK is not needed.
+      - name: Regenerate Room schemas
+        run: ./gradlew :app:kspDebugKotlin
+        env:
+          ENCRYPTION_PASSPHRASE: ${{ secrets.ENCRYPTION_PASSPHRASE }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Fail if no schema was exported
+        run: |
+          if [ -z "$(ls -A app/schemas 2>/dev/null)" ]; then
+            echo "ERROR: app/schemas is empty — the build exported no Room schemas."
+            exit 1
+          fi
+
+      - name: Commit and push updated schemas
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app/schemas
+          if git diff --cached --quiet; then
+            echo "No Room schema changes to commit."
+            exit 0
+          fi
+          git commit -m "Update Room schemas via regenerate-room-schemas workflow"
+          git push origin HEAD:${{ github.event.inputs.target_branch }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,21 @@ Always inject `DispatcherProvider` instead of using `Dispatchers.IO` directly. T
 ### Database Migrations
 Add new migrations in `migration/` following the `MIGRATION_N_(N+1).kt` naming convention, then register them in `VisitasDatabase.MIGRATIONS`.
 
+Bumping the `@Database` version also produces a new exported schema JSON in `app/schemas/`,
+which must be committed alongside the migration. Room exports these during **KSP compilation**
+(the `androidx.room` plugin copies them into the `schemaDirectory` set in `app/build.gradle.kts`) —
+the app does not need to be installed or launched, so `./gradlew :app:assembleDebug` is enough:
+
+```bash
+./gradlew :app:assembleDebug          # regenerates app/schemas/
+sh scripts/verify-room-schemas.sh     # asserts the committed schemas match
+```
+
+The PR build runs that same check (`Verify Room Schemas Are Committed`) against the schemas the
+build just regenerated, so a forgotten or stale schema JSON fails the PR. To fix it without
+building locally, dispatch the **Regenerate Room Schemas** workflow
+(`.github/workflows/regenerate-room-schemas.yml`) for your branch and it commits them for you.
+
 ## Build & Developer Workflows
 
 ### Build Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,13 +80,18 @@ Add new migrations in `migration/` following the `MIGRATION_N_(N+1).kt` naming c
 
 Bumping the `@Database` version also produces a new exported schema JSON in `app/schemas/`,
 which must be committed alongside the migration. Room exports these during **KSP compilation**
-(the `androidx.room` plugin copies them into the `schemaDirectory` set in `app/build.gradle.kts`) —
-the app does not need to be installed or launched, so `./gradlew :app:assembleDebug` is enough:
+(the `androidx.room` plugin's `copyRoomSchemas` task copies them into the `schemaDirectory` set in
+`app/build.gradle.kts`) — the app does not need to be installed or launched:
 
 ```bash
-./gradlew :app:assembleDebug          # regenerates app/schemas/
-sh scripts/verify-room-schemas.sh     # asserts the committed schemas match
+sh scripts/verify-room-schemas.sh                # export + assert committed schemas match
+sh scripts/verify-room-schemas.sh --export-only   # just regenerate app/schemas/
 ```
+
+**A plain `assembleDebug` is not enough to regenerate them.** The directory KSP writes schemas to
+is not a declared cacheable output of the KSP task, so whenever `kspDebugKotlin` is restored
+`FROM-CACHE` (the norm on CI) `copyRoomSchemas` reports `NO-SOURCE` and no schema is exported.
+The script therefore runs both tasks with `--rerun` and fails if nothing was written.
 
 The PR build runs that same check (`Verify Room Schemas Are Committed`) against the schemas the
 build just regenerated, so a forgotten or stale schema JSON fails the PR. To fix it without

--- a/scripts/verify-room-schemas.sh
+++ b/scripts/verify-room-schemas.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+#
+# Verify that the committed Room schema JSONs under app/schemas match the
+# ones the current sources produce.
+#
+# Room exports a schema JSON per database version at *compile* time — the
+# androidx.room Gradle plugin copies them from the KSP output into the
+# `schemaDirectory` configured in app/build.gradle.kts. No device, emulator
+# or app launch is involved, so a plain `./gradlew :app:assembleDebug` on a
+# CI runner regenerates them just as a local build does.
+#
+# Run this AFTER a debug build in the same workspace. It fails when:
+#   1. no schema exists for the @Database version declared in VisitasDatabase.kt
+#      (i.e. the build did not export schemas at all — which would make the
+#      diff check below vacuously green), or
+#   2. the build changed or added anything under app/schemas, meaning the
+#      generated schema was never committed.
+#
+# Usage:  ./gradlew :app:assembleDebug && sh scripts/verify-room-schemas.sh
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SCHEMA_ROOT="app/schemas"
+DATABASE_SOURCE="app/src/main/java/com/msmobile/visitas/VisitasDatabase.kt"
+
+if [ ! -f "$DATABASE_SOURCE" ]; then
+	echo "error: $DATABASE_SOURCE not found" >&2
+	exit 1
+fi
+
+# The `version = N` line inside the @Database annotation.
+DB_VERSION="$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$DATABASE_SOURCE" | head -n 1)"
+if [ -z "$DB_VERSION" ]; then
+	echo "error: could not read the @Database version from $DATABASE_SOURCE" >&2
+	exit 1
+fi
+
+echo "VisitasDatabase declares version $DB_VERSION"
+
+# 1. A schema for the declared version must have been exported.
+missing=1
+for schema_dir in "$SCHEMA_ROOT"/*; do
+	[ -d "$schema_dir" ] || continue
+	if [ -f "$schema_dir/$DB_VERSION.json" ]; then
+		echo "  + $schema_dir/$DB_VERSION.json"
+		missing=0
+	fi
+done
+
+if [ "$missing" -ne 0 ]; then
+	cat >&2 <<EOF
+error: no schema JSON for database version $DB_VERSION under $SCHEMA_ROOT/.
+
+The build should have exported it. Check that app/build.gradle.kts still has
+the androidx.room plugin applied with room { schemaDirectory(...) }, and that
+this script runs after a debug build in the same workspace.
+EOF
+	exit 1
+fi
+
+# 2. The build must not have changed or added anything under app/schemas.
+#    --porcelain also reports untracked files, so a brand-new N.json that was
+#    never committed is caught too.
+if [ -n "$(git status --porcelain -- "$SCHEMA_ROOT")" ]; then
+	echo >&2
+	echo "error: the build regenerated Room schemas that differ from the committed ones:" >&2
+	git status --short -- "$SCHEMA_ROOT" >&2
+	echo >&2
+	git --no-pager diff -- "$SCHEMA_ROOT" >&2
+	cat >&2 <<'EOF'
+
+Commit the regenerated schemas. Either build locally and commit the result:
+
+  ./gradlew :app:assembleDebug && git add app/schemas && git commit
+
+or dispatch the "Regenerate Room Schemas" workflow
+(.github/workflows/regenerate-room-schemas.yml) for this branch and let it
+commit them for you.
+EOF
+	exit 1
+fi
+
+echo "Room schemas are up to date."

--- a/scripts/verify-room-schemas.sh
+++ b/scripts/verify-room-schemas.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env sh
 #
-# Verify that the committed Room schema JSONs under app/schemas match the
-# ones the current sources produce.
+# Regenerate the Room schema JSONs under app/schemas and check they match what
+# is committed.
 #
-# Room exports a schema JSON per database version at *compile* time — the
-# androidx.room Gradle plugin copies them from the KSP output into the
-# `schemaDirectory` configured in app/build.gradle.kts. No device, emulator
-# or app launch is involved, so a plain `./gradlew :app:assembleDebug` on a
-# CI runner regenerates them just as a local build does.
+# Room exports a schema JSON per database version at *compile* time: KSP writes
+# them into a build intermediate directory, and the androidx.room Gradle plugin's
+# copyRoomSchemas task copies them into the `schemaDirectory` configured in
+# app/build.gradle.kts. No device, emulator or app launch is involved.
 #
-# Run this AFTER a debug build in the same workspace. It fails when:
-#   1. no schema exists for the @Database version declared in VisitasDatabase.kt
-#      (i.e. the build did not export schemas at all — which would make the
-#      diff check below vacuously green), or
-#   2. the build changed or added anything under app/schemas, meaning the
-#      generated schema was never committed.
+# Why this forces both tasks to re-run instead of piggybacking on a plain build:
+# the intermediate directory KSP writes to is not a declared, cacheable output
+# of the KSP task, so when kspDebugKotlin is restored FROM-CACHE (the normal case
+# on CI, where ~/.gradle is cached) the intermediate stays empty and
+# copyRoomSchemas reports NO-SOURCE — the export silently does not happen.
+# A check that merely diffed app/schemas after `assembleDebug` would then pass
+# without having regenerated anything. `--rerun` ignores both the up-to-date
+# check and the build cache for the requested tasks, and the freshness assertion
+# below fails loudly if the export still produces nothing.
 #
-# Usage:  ./gradlew :app:assembleDebug && sh scripts/verify-room-schemas.sh
+# Usage:
+#   sh scripts/verify-room-schemas.sh                 # export, then verify committed
+#   sh scripts/verify-room-schemas.sh --export-only   # export only (caller commits)
 
 set -eu
+
+EXPORT_ONLY=0
+case "${1:-}" in
+	--export-only) EXPORT_ONLY=1 ;;
+	'') ;;
+	*)
+		echo "usage: $0 [--export-only]" >&2
+		exit 2
+		;;
+esac
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
@@ -40,41 +54,69 @@ fi
 
 echo "VisitasDatabase declares version $DB_VERSION"
 
-# 1. A schema for the declared version must have been exported.
-missing=1
+# Delete the declared version's schema first, so its presence afterwards proves
+# the export actually wrote it. Comparing mtimes instead would be racy: `-nt` in
+# POSIX sh compares whole seconds, so an export finishing in the same second as
+# the reference file reads as "not newer" and the check would flake.
+# Deleting the destination also means a stale copyRoomSchemas up-to-date result
+# cannot keep the task from running.
+for schema_dir in "$SCHEMA_ROOT"/*; do
+	[ -d "$schema_dir" ] || continue
+	rm -f "$schema_dir/$DB_VERSION.json"
+done
+
+# copyRoomSchemas is contributed by the androidx.room plugin. If a Room upgrade
+# ever renames it, Gradle fails here with "task not found" — loudly, which is
+# the point: this check must never silently degrade into a no-op.
+./gradlew :app:kspDebugKotlin :app:copyRoomSchemas --rerun
+
+# 1. The export must have (re)created the declared version's schema.
+exported=1
 for schema_dir in "$SCHEMA_ROOT"/*; do
 	[ -d "$schema_dir" ] || continue
 	if [ -f "$schema_dir/$DB_VERSION.json" ]; then
-		echo "  + $schema_dir/$DB_VERSION.json"
-		missing=0
+		echo "  + $schema_dir/$DB_VERSION.json (exported by this run)"
+		exported=0
 	fi
 done
 
-if [ "$missing" -ne 0 ]; then
+if [ "$exported" -ne 0 ]; then
+	# Nothing was generated, so restore the file we deleted rather than leaving
+	# the working tree damaged. Safe here precisely because the export produced
+	# nothing — there is no new schema to preserve.
+	git checkout -- "$SCHEMA_ROOT" 2>/dev/null || true
 	cat >&2 <<EOF
-error: no schema JSON for database version $DB_VERSION under $SCHEMA_ROOT/.
 
-The build should have exported it. Check that app/build.gradle.kts still has
-the androidx.room plugin applied with room { schemaDirectory(...) }, and that
-this script runs after a debug build in the same workspace.
+error: the export produced no schema for database version $DB_VERSION under $SCHEMA_ROOT/.
+
+The Gradle run above did not write one, so this check cannot verify anything.
+Look for ':app:copyRoomSchemas NO-SOURCE' in its output. Check that
+app/build.gradle.kts still applies the androidx.room plugin with
+room { schemaDirectory(...) }, and that both task names above still exist.
 EOF
 	exit 1
 fi
 
-# 2. The build must not have changed or added anything under app/schemas.
+if [ "$EXPORT_ONLY" -eq 1 ]; then
+	echo "Room schemas exported."
+	exit 0
+fi
+
+# 2. The export must not have changed or added anything under app/schemas.
 #    --porcelain also reports untracked files, so a brand-new N.json that was
 #    never committed is caught too.
 if [ -n "$(git status --porcelain -- "$SCHEMA_ROOT")" ]; then
 	echo >&2
-	echo "error: the build regenerated Room schemas that differ from the committed ones:" >&2
+	echo "error: the exported Room schemas differ from the committed ones:" >&2
 	git status --short -- "$SCHEMA_ROOT" >&2
 	echo >&2
 	git --no-pager diff -- "$SCHEMA_ROOT" >&2
 	cat >&2 <<'EOF'
 
-Commit the regenerated schemas. Either build locally and commit the result:
+Commit the regenerated schemas. Either export locally and commit the result:
 
-  ./gradlew :app:assembleDebug && git add app/schemas && git commit
+  sh scripts/verify-room-schemas.sh --export-only
+  git add app/schemas && git commit
 
 or dispatch the "Regenerate Room Schemas" workflow
 (.github/workflows/regenerate-room-schemas.yml) for this branch and let it


### PR DESCRIPTION
## 📝 Description

Room schema export needs no device, emulator or app launch: the schemas are written during **KSP compilation**, and the `androidx.room` plugin's `copyRoomSchemas` task copies them into the `schemaDirectory` declared in `app/build.gradle.kts`. This PR makes CI check that the schema committed alongside a migration matches what the sources actually produce.

**Bumping the DB version and forgetting the schema JSON now fails the PR.** CI does not commit the file for you — the schema is a migration test fixture, so it should land in the migration commit and be reviewed. The escape hatch is the dispatchable **Regenerate Room Schemas** workflow, which commits it to your branch and re-triggers PR Build.

### There is a trap here, and the first revision of this PR fell into it

A plain `assembleDebug` does **not** reliably regenerate the schemas. The directory KSP writes them into is not a declared cacheable output of the KSP task, so when `kspDebugKotlin` is restored `FROM-CACHE` — the normal case on CI, where `~/.gradle` is cached — the intermediate stays empty and `copyRoomSchemas` reports `NO-SOURCE`. Nothing is exported.

The first revision diffed `app/schemas` after `assembleDebug` and asserted a schema exists for the declared `@Database` version. Its CI run did exactly the above (`> Task :app:copyRoomSchemas NO-SOURCE`) and passed anyway, because `13.json` exists by virtue of being committed. The regenerate workflow had the same bug: a cache hit would have committed nothing and reported success.

So both paths now go through the script, which:

- runs `:app:kspDebugKotlin :app:copyRoomSchemas --rerun`, bypassing both the up-to-date check and the build cache;
- **proves** the export happened by deleting the declared version's schema first and requiring it to reappear — a vacuous pass is structurally impossible;
- restores the deleted file if the export produced nothing (a failing check never leaves a damaged tree), but keeps it when the export produced *different* content, since that is what you need to commit.

Freshness is proven by delete-and-reappear rather than mtime comparison against a marker file: `-nt` in POSIX `sh` compares whole seconds, so an export finishing in the same second as the marker reads as "not newer" — that version flaked intermittently in testing before being replaced.

### Files

- **`scripts/verify-room-schemas.sh`** — forces the export, proves it happened, then asserts `git status --porcelain` is clean under `app/schemas` (so an untracked new `14.json` fails just like a modified one). `--export-only` skips the git assertion for callers that commit the result.
- **`.github/workflows/pull-request-build.yml`** — runs it after the existing build. Not free any more: it re-runs KSP for the debug variant.
- **`.github/workflows/regenerate-room-schemas.yml`** — dispatchable per branch, exports and commits via `WORKFLOW_TOKEN`, mirroring `regenerate-screenshots.yml`.
- **`AGENTS.md`** — documents the flow and the `FROM-CACHE`/`NO-SOURCE` trap under *Database Migrations*.

## 🐞 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors — no app sources changed; both workflow YAMLs parse, script passes `sh -n`
- [x] Tests pass locally — script exercised against five stubbed export outcomes: reproduces committed content (5/5 consecutive runs, confirming the flake is gone), no-op/`NO-SOURCE` export, differing content, brand-new version with no committed JSON, and `--export-only`. All behave as intended, including tree restore-vs-preserve.
- [ ] UI changes tested on device/emulator — n/a, no UI changes
- [x] Follows existing code patterns and conventions — POSIX-sh style of `scripts/sync-readme-screenshots.sh`; workflow mirrors `regenerate-screenshots.yml`

**Still unverified:** the Gradle half has never run here — no Android SDK in this environment — so the stubs stand in for it. This PR's own CI run is the first real test that `--rerun` on those two tasks exports the schema; if `copyRoomSchemas` still reports `NO-SOURCE`, the check will now fail loudly instead of passing, and I'll follow up.