### PR TITLE
Add feature-development skills for independent work

### DIFF
--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: add-feature
+description: Use when adding a brand-new feature slice (its own entity, screens, and package) to the Visitas app — the ordered map of every touch-point so nothing is missed
+---
+
+# Adding a new feature slice
+
+The full ordered set of touch-points for a new feature. For the per-file *shapes* (ViewModel/screen/test patterns) follow **AGENTS.md** — this skill is the map of everything you must touch, including the parts AGENTS.md scatters.
+
+## 1. Create the feature package `com.msmobile.visitas.<feature>`
+
+- `<Feature>.kt` — `@Entity(tableName = "<feature>")`, `@PrimaryKey val id: UUID` (UUIDs use the global `RoomUUIDConverter` — no per-field converter).
+- `<Feature>Dao.kt` — `@Dao interface`, `suspend` fns, `@Upsert save(...)`, `@Query` reads.
+- `<Feature>Repository.kt` — a **plain class** taking the DAO as a constructor arg (not `@Inject`/`@Singleton`).
+- `<Feature>ListViewModel.kt` / `<Feature>DetailViewModel.kt` — `@HiltViewModel @Inject constructor`; MVVM/UDF shape per AGENTS.md.
+- `<Feature>ListScreen.kt` / `<Feature>DetailScreen.kt` — `@Destination<RootGraph>(...)`; signature `(navigator, viewModel, appScaffoldState)`.
+- `<Feature>...PreviewConfigProvider.kt` — for the screenshot test.
+
+## 2. Register in Room (`VisitasDatabase.kt`)
+
+- Add `<Feature>::class` to `@Database(entities = [...])` (or `views = [...]` for a `@DatabaseView`).
+- Bump `version`.
+- Add `abstract fun <feature>Dao(): <Feature>Dao`.
+- Add `MIGRATION_N_M` (a `CREATE TABLE`) in `migration/` and to the `MIGRATIONS` array.
+- Regenerate + commit the exported schema JSON. **Don't hand-write the `CREATE TABLE` DDL from memory** — add the entity, bump the version, run `sh scripts/verify-room-schemas.sh --export-only`, then copy the exact `createSql` from the generated `app/schemas/.../<version>.json` into the migration. (Schema-export mechanics + the KSP-cache gotcha: AGENTS.md.)
+
+## 3. DI (`di/ApplicationModule.kt`) — two `@Provides` (easy to forget)
+
+Repositories are **not** `@Inject constructor`, so Hilt needs both:
+```kotlin
+@Singleton @Provides fun <feature>Dao(db: VisitasDatabase): <Feature>Dao = db.<feature>Dao()
+@Singleton @Provides fun <feature>Repository(dao: <Feature>Dao): <Feature>Repository = <Feature>Repository(dao)
+```
+Omitting the repository `@Provides` is a Hilt compile error, not a runtime one.
+
+## 4. Wire the ViewModel to the screen (`di/NavigationDependencies.kt`)
+
+```kotlin
+destination(<Feature>ListScreenDestination) {
+    dependency(hiltViewModel<<Feature>ListViewModel>())
+    dependency(appScaffoldState)
+}
+```
+This makes the destination buildable — **not reachable**.
+
+## 5. Make it reachable
+
+See the **`screen-reachability`** skill (tab / FAB / menu + the `AppScaffold` chrome lists).
+
+## 6. Screenshot test
+
+Add `<Feature>...ScreenshotTest.kt` in `app/src/screenshotTest/` + preview variants (AGENTS.md Screenshot Tests). Dispatch the Regenerate Screenshots workflow.
+
+## Cross-feature data & concurrent work
+
+- Needs data from another feature? → **`feature-decoupling`**.
+- Another feature being built in parallel? → **`parallel-feature-work`** (DB version + migration numbering collisions).

--- a/.claude/skills/feature-decoupling/SKILL.md
+++ b/.claude/skills/feature-decoupling/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: feature-decoupling
+description: Use when one feature package needs data or behavior owned by another (e.g. visit needs householder), when deciding where shared code goes, or when reviewing whether two features are too coupled
+---
+
+# Cross-feature boundaries
+
+Code is organized one package per feature (`visit`, `householder`, `conversation`, `summary`, …). `AGENTS.md` documents the intra-feature MVVM shape but **not** what may cross a package boundary. This is that rule.
+
+## The one invariant
+
+**The data/domain layer crosses feature boundaries; the presentation layer never does.**
+
+- **Entities** (`data class` like `Householder`, `Visit`) — cross freely; import them anywhere.
+- **The owning feature's Repository** — cross by **injecting it** into your ViewModel (every repository is a `@Singleton` `@Provides` in the single `di/ApplicationModule.kt`, so no extra wiring). Example: `VisitDetailViewModel` injects `HouseholderRepository`, `ConversationRepository`, `PreferenceRepository`.
+- **ViewModel / UiState / UiEvent / UiEventState** of another feature — **never**. They are effectively private to their feature.
+- **Composable / `*Screen`** of another feature — **never**. Reusable UI lives in `ui/views/`.
+- **Another feature's DAO** — avoid. Use its Repository, or add your own DAO / `@DatabaseView` in *your* package (see below).
+
+## How to consume feature B from feature A — pick by shape
+
+- **Need to write B's data, or read one record for a detail screen → inject B's Repository** into A's ViewModel, then **map B's entity into an A-local state type** at the VM edge. Never embed B's entity directly in A's `UiState`. (Default for detail/edit flows.)
+- **Need a foreign field alongside every row of a list → add a `@DatabaseView` in A** that joins the two tables. `visit/VisitHouseholder` joins `visit` + `householder`, is owned by `visit` (registered under `views = [...]`, see AGENTS.md), and feeds `VisitListViewModel`. Prefer this over N per-row repository lookups. Editing a view's SQL forces a DB version bump — see `modify-entity`.
+- **Pure read-model / aggregate over B's tables → add a DAO in A that queries B's table by name.** `summary/SummaryDao` does `SELECT … FROM Visit JOIN householder …` and owns no entity. Caveat: couples by **table-name string** — renaming B's table breaks A with no compiler error, only a Room-verification failure. Use sparingly.
+
+## Multi-feature screens: compose at the nav layer, never VM→VM
+
+When one screen needs several features, hand it **independent side-by-side ViewModels** in `di/NavigationDependencies.kt` (e.g. `VisitListScreenDestination` gets `VisitListViewModel` + `SummaryViewModel` + `BackupViewModel`). Each owns its own `StateFlow`; none references another. Do **not** make one ViewModel call another feature's ViewModel.
+
+## Where shared code belongs
+
+`util/` (cross-cutting services/providers), `extension/` (Kotlin extensions), `ui/theme/` + `ui/views/` (reusable Composables), `serialization/` (Moshi adapters), `di/ApplicationModule.kt` (the single DI module — no per-feature modules).
+
+## Too-coupled smells
+
+- A ViewModel importing another feature's ViewModel/UiState/UiEvent.
+- A Composable importing another feature's `*Screen` (→ move to `ui/views/`).
+- **Bidirectional** repository dependencies (A→B and B→A). Keep dependencies one-directional.
+- Embedding a foreign entity in your `UiState` instead of mapping it to a local type.

--- a/.claude/skills/modify-entity/SKILL.md
+++ b/.claude/skills/modify-entity/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: modify-entity
+description: Use when adding or changing a field on an existing Room entity (e.g. a new column on Visit) — the ordered steps including migration, schema, backup, UI, and tests
+---
+
+# Modifying an existing entity
+
+Ordered steps to add/change a field on an existing `@Entity`. Schema-export mechanics are in AGENTS.md; this is the end-to-end flow.
+
+## Steps
+
+1. **Add the field with a Kotlin default** in `<feature>/<Feature>.kt`, so existing call sites and backup/restore keep compiling. The Kotlin default and the migration's column default must agree. Precedent: `isDraft: Boolean = false`, `calendarEventId: Long? = null`.
+
+2. **Bump the `@Database` version** in `VisitasDatabase.kt` (`14` → `15`). Multiple schema changes landing together on one branch share **one** version bump and **one** migration doing all the DDL — don't burn a version number per column.
+
+3. **Write + register the migration** — new `migration/Migration_N_M.kt` matching `Migration_13_14.kt` style (anonymous `Migration(N, M)`, val `MIGRATION_N_M`, KDoc). Then append it to the `MIGRATIONS` array.
+   ```kotlin
+   db.execSQL("ALTER TABLE `visit` ADD COLUMN `phoneCallReminder` INTEGER NOT NULL DEFAULT 0")
+   ```
+   `Boolean` → `INTEGER NOT NULL DEFAULT 0`. For non-null `String`/enum columns, confirm the exact `DEFAULT` against Room's generated schema.
+
+4. **Regenerate + commit the schema JSON** (`app/schemas/.../<version>.json`): `sh scripts/verify-room-schemas.sh --export-only` then `sh scripts/verify-room-schemas.sh`. The PR build fails on a stale/missing JSON. (KSP-cache caveat + Regenerate Room Schemas workflow: AGENTS.md.)
+
+5. **Mirror/embedded tables — check for a second table to ALTER.** If the entity is `@Embedded` in another entity, that table has the same columns and needs the **same `ALTER` in the same migration**. `Visit` is embedded in `VisitSnapshot` (table `visit_snapshot`, the discard-draft copy), so a new `Visit` column means two `ALTER TABLE` statements — `visit` **and** `visit_snapshot` — plus the matching Kotlin default. Miss this and draft-discard/restore breaks.
+
+6. **DAO — usually nothing.** `@Upsert` + `SELECT *` round-trip the new column automatically. Only touch a DAO if the field must be **projected or filtered**:
+   - Shown in the list view → add it to the `VisitHouseholder` `@DatabaseView` SQL + data class. **A view is part of the schema hash, so this also forces the version bump** — fold it into the same bump.
+   - Needed by `summary` → edit `SummaryDao`'s raw SQL (no schema change, but table-name-string coupled).
+
+7. **Backup/restore — verify, usually no change.** `BackupHandler` copies whole rows, and restoring an older backup runs `MIGRATIONS` on it — which is exactly why step 3 must exist and be registered.
+
+8. **UI plumbing** (only if user-visible) in `<Feature>DetailViewModel.kt`: add the field to the editable/state data class, thread it through the `asState`/`asModel` mappers, and if editable add a `UiEvent` + `onEvent` branch + the control in the screen.
+
+9. **Tests** — update the affected unit VM test via the `createViewModel()` factory pattern; for UI changes **append a new screenshot variant** (never mutate shared preview state). Both per AGENTS.md.
+
+## Gotcha: pre-commit hook needs a device
+
+Editing `VisitasDatabase.kt` (which step 2 does) triggers `BackupHandlerTest` in the pre-commit hook, which **requires a connected device/emulator**. Have one attached when committing.
+
+## Concurrent work
+
+Two entity changes in flight collide on the DB version number and schema JSON — see **`parallel-feature-work`**.

--- a/.claude/skills/parallel-feature-work/SKILL.md
+++ b/.claude/skills/parallel-feature-work/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: parallel-feature-work
+description: Use when two or more features/entities are being developed at the same time (separate branches, worktrees, or agents) and you need to avoid collisions on shared registries and the Room DB version
+---
+
+# Parallel feature work
+
+Each feature is a mostly-isolated package, but every feature touches a handful of **shared registries** and the **Room DB version**. Two features in flight will collide there. Plan for it.
+
+## Highest risk: the Room DB version number
+
+Both features bump `@Database(version = N)` to `N+1` and each adds `MIGRATION_N_(N+1)`. Git may auto-merge the text, but the result is **semantically broken** — you'd have two version-15 migrations and one declared version.
+
+**Rule — land DB changes sequentially.** The second-to-land branch rebases and:
+1. Takes the **next** version (`16`, not `15`).
+2. Renames its migration to the correct contiguous pair (`MIGRATION_15_16`, file `Migration_15_16.kt`).
+3. **Regenerates** the schema JSON — never hand-merge a generated `app/schemas/.../<version>.json`. Delete the conflicted file and re-run `sh scripts/verify-room-schemas.sh --export-only` (see `modify-entity` / AGENTS.md).
+
+## Shared registries (mergeable, but plan additive edits)
+
+Append on their own lines at the end of each list to minimize conflicts; resolve by keeping both:
+
+- `VisitasDatabase.kt` — `entities`/`views` array, `MIGRATIONS` array, abstract-DAO block.
+- `di/ApplicationModule.kt` — `@Provides` for DAO + repository.
+- `di/NavigationDependencies.kt` — `destination(...)` blocks.
+- `AppScaffold.kt` — `showFAB` / `showTopBar` / `showBottomNavigation` lists + the `title` `when`.
+- `ui/views/BottomNavigation.kt` — `BottomNavigationTab` enum.
+- `MainActivityViewModel.kt` — `asFabDestination` mapping.
+- `res/values/strings.xml` — use **feature-prefixed** string keys (`tag_title`, not `title`) to avoid duplicate-key clashes.
+- Screenshot reference PNGs — shared detail chrome (`DetailFooterAction`) means one change can shift several references; regenerate via the workflow, don't hand-edit.
+
+## Not a concern
+
+KSP-generated artifacts (`NavGraphs`, `VisitasDatabase_Impl`, Hilt registries) live under `build/` and aren't committed — no git conflict. A stale build cache after a merge can produce confusing errors; a clean rebuild fixes it.
+
+## Isolation
+
+Give each concurrent feature its own workspace so their uncommitted edits to shared files don't interleave — see the `superpowers:using-git-worktrees` skill.

--- a/.claude/skills/screen-reachability/SKILL.md
+++ b/.claude/skills/screen-reachability/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: screen-reachability
+description: Use when adding a new screen/destination and needing to make it actually reachable — as a bottom-nav tab, from the FAB, or from a menu — beyond just registering its ViewModel
+---
+
+# Making a screen reachable
+
+Navigation is **Compose Destinations** (KSP-generated `NavGraphs`). Annotating a screen `@Destination<RootGraph>` and registering its ViewModel in `di/NavigationDependencies.kt` (see AGENTS.md) makes the destination **buildable but not reachable**. To make it reachable, pick one entry surface and also update the app-level chrome lists.
+
+## Entry surfaces (pick one)
+
+**Bottom-nav tab** — add an entry to the `BottomNavigationTab` enum in `ui/views/BottomNavigation.kt`:
+```kotlin
+Tags(TagListScreenDestination, Icons.Rounded.Label, R.string.tags),
+```
+
+**FAB → detail** — add the list→detail mapping in `MainActivityViewModel.asFabDestination`:
+```kotlin
+is TagListScreenDestination -> TagDetailScreenDestination
+```
+
+**From a menu / another screen** — navigate with the generated `TagListScreenDestination` via `DestinationsNavigator` (mirror how `settingsTopMenuActions` reaches `SettingsScreenDestination`).
+
+## Always update the chrome lists in `AppScaffold.kt`
+
+The app-level Scaffold gates chrome by destination (see the `scaffold-architecture` skill). Add your destination to the relevant lists:
+
+- `showTopBar` — if the screen has the app top bar.
+- `showBottomNavigation` — if it's a tab.
+- `showFAB` — if it shows the FAB.
+- the `title` `when (currentDestination)` — add a branch, else it falls back to `app_name`.
+
+## Gotchas
+
+- A tab **without** a detail screen still hits `showFAB` logic — either exclude it from `showFAB` and use an on-screen add button, or give it a detail destination and an `asFabDestination` mapping.
+- Add a **feature-prefixed** string resource for the title/label (avoid generic keys like `tags`) — see `parallel-feature-work` for why.
+- These files (`AppScaffold.kt`, `BottomNavigation.kt`, `MainActivityViewModel.kt`, `NavigationDependencies.kt`) are shared collision hotspots — see `parallel-feature-work`.


### PR DESCRIPTION
## 📝 Description
Adds five focused project skills that make feature **creation and modification** as independent as possible — self-sufficient sessions, architectural decoupling, and parallel-safe workflows.

Each skill targets a gap **confirmed by baseline subagent runs** (agents attempting real feature tasks *without* the skills and reporting where they had to guess) and deliberately **cross-references `AGENTS.md` instead of duplicating it** — AGENTS.md already covers the MVVM slice, migrations, schema export, and testing.

New skills:
- `add-feature` — the ordered map of every touch-point for a new feature slice (package files, Room registration, DI `@Provides` for DAO + repository, nav wiring, reachability, screenshot test).
- `modify-entity` — adding/changing a field on an existing Room entity end-to-end, incl. the embedded mirror-table (`visit_snapshot`) ALTER, schema regeneration, backup/restore, and the device-dependent pre-commit hook.
- `feature-decoupling` — what may cross a feature-package boundary (entities + repositories cross; ViewModel/UiState/Composable never do), which cross-feature mechanism to use by shape, and compose-at-the-nav-layer.
- `screen-reachability` — how a destination actually becomes reachable (bottom-nav tab / FAB→detail / menu) plus the `AppScaffold` chrome lists.
- `parallel-feature-work` — collision playbook for concurrent features: DB version numbering, migration renaming, schema-JSON regenerate-don't-merge, shared registries, worktree isolation.

Methodology: RED (baseline subagents surface gaps) → GREEN (author against gaps) → verify with a subagent GAP CHECK → REFACTOR (closed two real gaps the check found: embedded mirror-table ALTER, and cross-feature mechanism choice).

## 🐞 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other (please describe):

## ☑️ Checklist

- [x] Code compiles without errors <!-- N/A — docs/skills only, no app code changed -->
- [x] Tests pass locally <!-- N/A — no app code changed -->
- [x] UI changes tested on device/emulator <!-- N/A — no UI changes -->
- [x] Follows existing code patterns and conventions <!-- matches existing .claude/skills/ layout; conventions verified against current source -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
